### PR TITLE
Add Next.js dashboard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.db
+.pytest_cache/
+client/node_modules/
+client/.next/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ flake8
 pytest
 ```
 
+## Frontend Dashboard
+
+The dashboard lives in the `client/` directory and uses Next.js with Tailwind CSS.
+To start it locally:
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
 ## Trend Categories
 The `/trends` service exposes popular niches such as animals and pets, activism,
 families and couples, humor and memes, job or hobby related topics, health and

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <nav className="bg-gray-800 text-white p-4">
+        <div className="container mx-auto flex gap-4">
+          <Link href="/" className="hover:underline">Home</Link>
+          <Link href="/generate" className="hover:underline">Generate</Link>
+        </div>
+      </nav>
+      <main className="flex-1 container mx-auto p-4">{children}</main>
+    </div>
+  );
+}

--- a/client/next-env.d.ts
+++ b/client/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pod-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.4.5",
+    "tailwindcss": "3.4.5",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.17",
+    "axios": "1.6.8"
+  }
+}

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import Layout from '../components/Layout';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/client/pages/generate.tsx
+++ b/client/pages/generate.tsx
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import { useState } from 'react';
+
+export default function Generate() {
+  const [term, setTerm] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResult(null);
+    try {
+      const res = await axios.post(`${api}/generate`, { term });
+      setResult(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-2">Generate Product Idea</h1>
+      <form onSubmit={submit} className="flex gap-2">
+        <input
+          type="text"
+          className="border p-2 flex-grow"
+          placeholder="Enter trend term"
+          value={term}
+          onChange={e => setTerm(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Generate
+        </button>
+      </form>
+      {result && (
+        <div className="bg-gray-100 p-4 rounded">
+          <pre className="whitespace-pre-wrap text-sm">
+{JSON.stringify(result, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+type Trend = { term: string; category: string };
+
+type TrendsByCategory = Record<string, string[]>;
+
+export default function Home() {
+  const [trends, setTrends] = useState<TrendsByCategory>({});
+  const [events, setEvents] = useState<string[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await axios.get<Trend[]>(`${api}/trends`);
+        const grouped: TrendsByCategory = {};
+        res.data.forEach(t => {
+          if (!grouped[t.category]) grouped[t.category] = [];
+          grouped[t.category].push(t.term);
+        });
+        setTrends(grouped);
+        const month = new Date().toLocaleString('default', { month: 'long' }).toLowerCase();
+        const ev = await axios.get<{ month: string; events: string[] }>(`${api}/events/${month}`);
+        setEvents(ev.data.events);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, [api]);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Trending Keywords</h1>
+      {Object.entries(trends).map(([cat, terms]) => (
+        <div key={cat}>
+          <h2 className="text-xl font-semibold capitalize">{cat}</h2>
+          <ul className="list-disc list-inside pl-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-1">
+            {terms.map(term => (
+              <li key={term}>{term}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      <div>
+        <h2 className="text-xl font-semibold mt-4">This Month's Events</h2>
+        <ul className="list-disc list-inside pl-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-1">
+          {events.map(ev => (
+            <li key={ev}>{ev}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,16 @@ services:
   gateway:
     build: .
     command: uvicorn services.gateway.api:app --port 8000 --host 0.0.0.0
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./client:/app
+    command: sh -c "npm install && npm run build && npm start"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - gateway
   worker:
     build: .
     command: celery -A services.tasks worker -l info


### PR DESCRIPTION
## Summary
- add minimal Next.js project under `client/`
- wire dashboard layout, index and generate pages
- document running the frontend in README
- add frontend service to docker-compose
- ignore node build artifacts

## Testing
- `pytest -q`
- `flake8`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6880b2c6c934832bac7f0e38d6a9bbc3