### PR TITLE
Add trending product categories endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ returns Valentine’s Day, the Super Bowl and more.
 Top print‑on‑demand categories include apparel, home decor, drinkware and
 accessories. Among apparel, t‑shirts, sportswear and leggings are the most
 popular products.
+
+## Trending Product Categories
+The `/product-categories` endpoint returns 2025’s leading niches based on market
+research. Categories include apparel, home_decor, pet_items, jewelry,
+accessories, tech_accessories, athletic_accessories and holiday_items. These
+lists show that unisex t‑shirts, hoodies, leggings, mugs and posters lead sales.
+
+Start the frontend and navigate to `/categories` to view them.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -8,6 +8,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <div className="container mx-auto flex gap-4">
           <Link href="/" className="hover:underline">Home</Link>
           <Link href="/generate" className="hover:underline">Generate</Link>
+          <Link href="/categories" className="hover:underline">Categories</Link>
         </div>
       </nav>
       <main className="flex-1 container mx-auto p-4">{children}</main>

--- a/client/pages/categories.tsx
+++ b/client/pages/categories.tsx
@@ -1,0 +1,40 @@
+import { GetServerSideProps } from 'next';
+import axios from 'axios';
+
+export type ProductCategory = {
+  name: string;
+  items: string[];
+};
+
+type CategoriesProps = {
+  categories: ProductCategory[];
+};
+
+export default function Categories({ categories }: CategoriesProps) {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Trending Categories</h1>
+      {categories.map(cat => (
+        <div key={cat.name} className="mb-4">
+          <h2 className="text-xl font-semibold capitalize">{cat.name}</h2>
+          <ul className="list-disc list-inside pl-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-1">
+            {cat.items.map(item => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<CategoriesProps> = async () => {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  try {
+    const res = await axios.get<ProductCategory[]>(`${api}/product-categories`);
+    return { props: { categories: res.data } };
+  } catch (err) {
+    console.error(err);
+    return { props: { categories: [] } };
+  }
+};

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from fastapi import FastAPI
-from ..trend_scraper.service import fetch_trends
+from ..trend_scraper.service import fetch_trends, get_trending_categories
 from ..ideation.service import generate_ideas
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
@@ -21,3 +21,8 @@ async def generate():
     listing["listing_url"] = listing.get("etsy_url")
     listing["events"] = events
     return listing
+
+
+@app.get("/product-categories")
+async def product_categories(category: str | None = None):
+    return get_trending_categories(category)

--- a/services/ideation/service.py
+++ b/services/ideation/service.py
@@ -23,8 +23,12 @@ async def generate_ideas(trends: List[TrendInput]) -> List[Dict]:
     key = os.getenv("OPENAI_API_KEY")
     month = datetime.utcnow().strftime("%B").lower()
     events = EVENTS.get(month, [])
+    prompt_events = ", ".join(events)
     prompts = [
-        f"Generate a product idea for the {cat} niche around '{term}'. Consider upcoming {', '.join(events)}"
+        (
+            f"Generate a product idea for the {cat} niche around '{term}'. "
+            f"Consider upcoming {prompt_events}"
+        )
         for term, cat in formatted
     ]
 

--- a/services/trend_scraper/api.py
+++ b/services/trend_scraper/api.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import fetch_trends
+from .service import fetch_trends, get_trending_categories
 from .events import EVENTS
 from ..tasks import celery_app
 
@@ -23,8 +23,18 @@ class EventsResponse(BaseModel):
     events: list[str]
 
 
+class ProductCategory(BaseModel):
+    name: str
+    items: list[str]
+
+
 @app.get("/events/{month}", response_model=EventsResponse)
 async def get_events(month: str):
     month_key = month.lower() if month else datetime.utcnow().strftime("%B").lower()
     events = EVENTS.get(month_key, [])
     return {"month": month_key.capitalize(), "events": events}
+
+
+@app.get("/categories", response_model=list[ProductCategory])
+async def get_categories(category: str | None = None):
+    return get_trending_categories(category)

--- a/services/trend_scraper/service.py
+++ b/services/trend_scraper/service.py
@@ -57,6 +57,81 @@ FALLBACK_TRENDS = {
     ],
 }
 
+# Fallback product categories for 2025 based on market research
+FALLBACK_CATEGORIES = {
+    "apparel": [
+        "unisex t-shirts",
+        "oversized hoodies",
+        "athleisure",
+        "yoga pants",
+        "leggings",
+    ],
+    "home_decor": [
+        "coffee mugs",
+        "canvases",
+        "posters",
+        "acrylic plaques",
+        "metal prints",
+        "wall decals",
+        "doormats",
+        "carpets",
+        "pillows",
+        "blankets",
+        "candles",
+        "coasters",
+    ],
+    "pet_items": [
+        "harnesses",
+        "leashes",
+        "bandanas",
+        "pet clothing",
+        "beds",
+        "bowls",
+        "collars",
+        "tags",
+        "blankets",
+    ],
+    "jewelry": ["engraved bracelets", "engraved necklaces"],
+    "accessories": [
+        "tote bags",
+        "stickers",
+        "caps",
+        "backpacks",
+        "bandanas",
+        "patches",
+        "socks",
+        "beanies",
+        "bucket hats",
+        "flip-flops",
+        "belt bags",
+    ],
+    "tech_accessories": [
+        "phone cases",
+        "wireless chargers",
+        "mousepads",
+        "laptop sleeves",
+        "popsocket grips",
+        "bluetooth speakers",
+        "water bottles",
+    ],
+    "athletic_accessories": [
+        "yoga mats",
+        "gym gear",
+        "gloves",
+        "backpacks",
+        "duffle bags",
+    ],
+    "holiday_items": [
+        "Valentine’s shirts",
+        "Mother’s Day tote bags",
+        "Father’s Day cards",
+        "Halloween costumes",
+        "Christmas ornaments",
+        "New Year greeting cards",
+        "back-to-school stationery",
+    ],
+}
+
 
 async def fetch_trends(category: str | None = None) -> List[dict]:
     terms = []
@@ -90,3 +165,17 @@ async def fetch_trends(category: str | None = None) -> List[dict]:
             await session.refresh(trend)
             trends.append({"term": trend.term, "category": trend.category})
     return trends
+
+
+def get_trending_categories(category: str | None = None) -> List[dict]:
+    """Return 2025 trending product categories and popular items."""
+
+    if category:
+        key = category.lower()
+        items = FALLBACK_CATEGORIES.get(key)
+        if items:
+            return [{"name": key, "items": items}]
+        return []
+    return [
+        {"name": name, "items": items} for name, items in FALLBACK_CATEGORIES.items()
+    ]

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # noqa: E402
+
+import pytest  # noqa: E402
+from httpx import AsyncClient, ASGITransport  # noqa: E402
+from services.gateway.api import app as gateway_app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_product_categories_endpoint():
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/product-categories")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 5
+        apparel = next((c for c in data if c["name"] == "apparel"), None)
+        assert apparel is not None
+        assert any("unisex t-shirts" in item for item in apparel["items"])


### PR DESCRIPTION
## Summary
- add 2025 trending product categories constants and service helper
- expose `/categories` in the trend_scraper microservice
- surface categories via gateway at `/product-categories`
- implement Categories page in Next.js and link in layout
- add unit tests for new endpoint
- document categories endpoint and examples in README

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880b8cc84d0832bbf694f8c77950522