### PR TITLE
Add design inspiration endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,9 @@ accessories, tech_accessories, athletic_accessories and holiday_items. These
 lists show that unisex t‑shirts, hoodies, leggings, mugs and posters lead sales.
 
 Start the frontend and navigate to `/categories` to view them.
+
+## Design Inspirations
+The `/design-ideas` endpoint returns trending design themes for 2025 such as
+photo uploads, besties & couples, animals & pets and more. Each category
+includes example product ideas like personalized acrylic plaques or photo
+blankets. View them in the dashboard at `/design`.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -9,6 +9,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/" className="hover:underline">Home</Link>
           <Link href="/generate" className="hover:underline">Generate</Link>
           <Link href="/categories" className="hover:underline">Categories</Link>
+          <Link href="/design" className="hover:underline">Design Ideas</Link>
         </div>
       </nav>
       <main className="flex-1 container mx-auto p-4">{children}</main>

--- a/client/pages/design.tsx
+++ b/client/pages/design.tsx
@@ -1,0 +1,42 @@
+import { GetServerSideProps } from 'next';
+import axios from 'axios';
+
+export type DesignIdea = {
+  name: string;
+  ideas: string[];
+};
+
+type DesignProps = {
+  designs: DesignIdea[];
+};
+
+export default function Design({ designs }: DesignProps) {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Design Ideas</h1>
+      {designs.map(d => (
+        <div key={d.name} className="mb-4">
+          <h2 className="text-xl font-semibold capitalize">
+            {d.name.replace(/_/g, ' ')}
+          </h2>
+          <ul className="list-disc list-inside pl-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-1">
+            {d.ideas.map(idea => (
+              <li key={idea}>{idea}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<DesignProps> = async () => {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  try {
+    const res = await axios.get<DesignIdea[]>(`${api}/design-ideas`);
+    return { props: { designs: res.data } };
+  } catch (err) {
+    console.error(err);
+    return { props: { designs: [] } };
+  }
+};

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 from fastapi import FastAPI
-from ..trend_scraper.service import fetch_trends, get_trending_categories
+from ..trend_scraper.service import (
+    fetch_trends,
+    get_trending_categories,
+    get_design_ideas,
+)
 from ..ideation.service import generate_ideas
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
@@ -26,3 +30,8 @@ async def generate():
 @app.get("/product-categories")
 async def product_categories(category: str | None = None):
     return get_trending_categories(category)
+
+
+@app.get("/design-ideas")
+async def design_ideas(category: str | None = None):
+    return get_design_ideas(category)

--- a/services/trend_scraper/api.py
+++ b/services/trend_scraper/api.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import fetch_trends, get_trending_categories
+from .service import fetch_trends, get_trending_categories, get_design_ideas
 from .events import EVENTS
 from ..tasks import celery_app
 
@@ -28,6 +28,11 @@ class ProductCategory(BaseModel):
     items: list[str]
 
 
+class DesignIdeaCategory(BaseModel):
+    name: str
+    ideas: list[str]
+
+
 @app.get("/events/{month}", response_model=EventsResponse)
 async def get_events(month: str):
     month_key = month.lower() if month else datetime.utcnow().strftime("%B").lower()
@@ -38,3 +43,8 @@ async def get_events(month: str):
 @app.get("/categories", response_model=list[ProductCategory])
 async def get_categories(category: str | None = None):
     return get_trending_categories(category)
+
+
+@app.get("/design-ideas", response_model=list[DesignIdeaCategory])
+async def design_ideas(category: str | None = None):
+    return get_design_ideas(category)

--- a/services/trend_scraper/service.py
+++ b/services/trend_scraper/service.py
@@ -132,6 +132,94 @@ FALLBACK_CATEGORIES = {
     ],
 }
 
+# Trending design inspiration categories for 2025
+FALLBACK_DESIGN_INSPIRATIONS = {
+    "photo_upload": [
+        "personalized acrylic plaques",
+        "photo blankets",
+        "photo puzzles",
+    ],
+    "besties_couples": [
+        "matching t-shirts",
+        "custom mugs",
+        "friendship bracelets",
+    ],
+    "word_repeat": [
+        "stacked text hoodies",
+        "monotone word art posters",
+    ],
+    "text_quotes": [
+        "motivational quote canvas",
+        "sassy statement mugs",
+        "hand-lettered wall art",
+    ],
+    "animals_pets": [
+        "pet portrait tees",
+        "custom pet bandanas",
+        "paw print blankets",
+    ],
+    "landscapes": [
+        "sunset mountain posters",
+        "beach scene canvases",
+        "city skyline art",
+    ],
+    "cartoon_characters_superheroes": [
+        "fan art hoodies",
+        "superhero mugs",
+        "comic style stickers",
+    ],
+    "3d_effects": [
+        "holographic decals",
+        "3D typography shirts",
+        "layered shadow posters",
+    ],
+    "brush_strokes": [
+        "abstract brush stroke prints",
+        "paint splatter tees",
+        "modern art canvases",
+    ],
+    "pop_culture": [
+        "viral meme shirts",
+        "nostalgic tv quote mugs",
+        "music lyric posters",
+    ],
+    "crypto_themes": [
+        "bitcoin slogan shirts",
+        "blockchain meme stickers",
+        "NFT-inspired prints",
+    ],
+    "funny_daily_life": [
+        "work-from-home humor mugs",
+        "parenting fails tees",
+        "coffee addiction stickers",
+    ],
+    "minimalism": [
+        "simple line art tees",
+        "monochrome posters",
+        "clean typography stickers",
+    ],
+    "vintage_retro": [
+        "70s sunset tees",
+        "retro typography posters",
+        "distressed logo mugs",
+    ],
+    "y2k_nostalgia": [
+        "2000s clipart stickers",
+        "sparkle gradient shirts",
+        "vaporwave canvases",
+    ],
+    "goblincore_cottagecore": [
+        "mushroom forest art",
+        "gothic cottage mugs",
+        "garden sprite tees",
+    ],
+    "eco_humor": [
+        "recycle joke stickers",
+        "sustainability pun tees",
+        "green living posters",
+    ],
+}
+
 
 async def fetch_trends(category: str | None = None) -> List[dict]:
     terms = []
@@ -178,4 +266,19 @@ def get_trending_categories(category: str | None = None) -> List[dict]:
         return []
     return [
         {"name": name, "items": items} for name, items in FALLBACK_CATEGORIES.items()
+    ]
+
+
+def get_design_ideas(category: str | None = None) -> List[dict]:
+    """Return trending design inspirations filtered by category."""
+
+    if category:
+        key = category.lower()
+        ideas = FALLBACK_DESIGN_INSPIRATIONS.get(key)
+        if ideas:
+            return [{"name": key, "ideas": ideas}]
+        return []
+    return [
+        {"name": name, "ideas": ideas}
+        for name, ideas in FALLBACK_DESIGN_INSPIRATIONS.items()
     ]

--- a/tests/test_design_ideas.py
+++ b/tests/test_design_ideas.py
@@ -1,0 +1,26 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.gateway.api import app as gateway_app
+
+
+@pytest.mark.asyncio
+async def test_design_ideas_endpoint():
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/design-ideas")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 5
+        found = False
+        for cat in data:
+            ideas = cat.get("ideas", [])
+            if any("acrylic" in i.lower() or "blanket" in i.lower() for i in ideas):
+                found = True
+        assert found
+
+        resp = await client.get("/design-ideas", params={"category": "animals_pets"})
+        assert resp.status_code == 200
+        filtered = resp.json()
+        assert len(filtered) == 1
+        assert filtered[0]["name"] == "animals_pets"


### PR DESCRIPTION
## Summary
- provide fallback design inspirations in `trend_scraper` service
- expose `/design-ideas` endpoint in trend_scraper and gateway
- add Next.js page to display design ideas
- link to new page from layout navigation
- document endpoint in README
- add integration tests for `/design-ideas`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c347575c832bb0367087acb496e7