### PR TITLE
Add product suggestions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ The `/design-ideas` endpoint returns trending design themes for 2025 such as
 photo uploads, besties & couples, animals & pets and more. Each category
 includes example product ideas like personalized acrylic plaques or photo
 blankets. View them in the dashboard at `/design`.
+
+## Product Suggestions
+`/product-suggestions` combines trending categories with design inspirations so
+you can quickly brainstorm new listings. Categories include apparel, home decor,
+pet items, jewelry, accessories, tech accessories, athletic accessories and
+holiday items. Design themes span photo upload, besties/couples, word repeat,
+text quotes, animals/pets, landscapes, cartoon characters/superheroes, 3D
+effects, brush strokes, pop culture, crypto themes, funny daily life,
+minimalism, vintage/retro, y2k nostalgia, goblincore/cottagecore and eco humor.
+Visit `/suggestions` in the dashboard to see up to ten phrases like "sunset
+mountain posters" or "paw print blankets" mixed with product types.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -10,6 +10,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/generate" className="hover:underline">Generate</Link>
           <Link href="/categories" className="hover:underline">Categories</Link>
           <Link href="/design" className="hover:underline">Design Ideas</Link>
+          <Link href="/suggestions" className="hover:underline">Suggestions</Link>
         </div>
       </nav>
       <main className="flex-1 container mx-auto p-4">{children}</main>

--- a/client/pages/suggestions.tsx
+++ b/client/pages/suggestions.tsx
@@ -1,0 +1,108 @@
+import { GetServerSideProps } from 'next';
+import axios from 'axios';
+import { useState } from 'react';
+
+export type Suggestion = {
+  category: string;
+  design_theme: string;
+  suggestion: string;
+};
+
+interface SuggestionsProps {
+  suggestions: Suggestion[];
+  categories: string[];
+  designs: string[];
+}
+
+export default function Suggestions({ suggestions: initial, categories, designs }: SuggestionsProps) {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>(initial);
+  const [category, setCategory] = useState('');
+  const [design, setDesign] = useState('');
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await axios.get<Suggestion[]>(`${api}/product-suggestions`, {
+        params: {
+          category: category || undefined,
+          design: design || undefined,
+        },
+      });
+      setSuggestions(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Product Suggestions</h1>
+      <form onSubmit={submit} className="flex flex-wrap gap-2 items-end">
+        <div>
+          <label className="block text-sm font-medium">Category</label>
+          <select
+            value={category}
+            onChange={e => setCategory(e.target.value)}
+            className="border p-2 w-48"
+          >
+            <option value="">All</option>
+            {categories.map(c => (
+              <option key={c} value={c}>
+                {c.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium">Design Theme</label>
+          <select
+            value={design}
+            onChange={e => setDesign(e.target.value)}
+            className="border p-2 w-48"
+          >
+            <option value="">All</option>
+            {designs.map(d => (
+              <option key={d} value={d}>
+                {d.replace(/_/g, ' ')}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Fetch
+        </button>
+      </form>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {suggestions.map((s, idx) => (
+          <div key={idx} className="border p-4 rounded">
+            <h3 className="font-semibold capitalize">{s.category}</h3>
+            <p className="text-sm italic">{s.design_theme.replace(/_/g, ' ')}</p>
+            <p className="mt-2">{s.suggestion}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<SuggestionsProps> = async () => {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  try {
+    const [sRes, cRes, dRes] = await Promise.all([
+      axios.get<Suggestion[]>(`${api}/product-suggestions`),
+      axios.get<{ name: string }[]>(`${api}/product-categories`),
+      axios.get<{ name: string }[]>(`${api}/design-ideas`),
+    ]);
+    return {
+      props: {
+        suggestions: sRes.data,
+        categories: cRes.data.map(c => c.name),
+        designs: dRes.data.map(d => d.name),
+      },
+    };
+  } catch (err) {
+    console.error(err);
+    return { props: { suggestions: [], categories: [], designs: [] } };
+  }
+};

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -4,6 +4,7 @@ from ..trend_scraper.service import (
     fetch_trends,
     get_trending_categories,
     get_design_ideas,
+    get_product_suggestions,
 )
 from ..ideation.service import generate_ideas
 from ..image_gen.service import generate_images
@@ -35,3 +36,8 @@ async def product_categories(category: str | None = None):
 @app.get("/design-ideas")
 async def design_ideas(category: str | None = None):
     return get_design_ideas(category)
+
+
+@app.get("/product-suggestions")
+async def product_suggestions(category: str | None = None, design: str | None = None):
+    return get_product_suggestions(category, design)

--- a/services/trend_scraper/api.py
+++ b/services/trend_scraper/api.py
@@ -1,7 +1,12 @@
 from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import fetch_trends, get_trending_categories, get_design_ideas
+from .service import (
+    fetch_trends,
+    get_trending_categories,
+    get_design_ideas,
+    get_product_suggestions,
+)
 from .events import EVENTS
 from ..tasks import celery_app
 
@@ -33,6 +38,12 @@ class DesignIdeaCategory(BaseModel):
     ideas: list[str]
 
 
+class Suggestion(BaseModel):
+    category: str
+    design_theme: str
+    suggestion: str
+
+
 @app.get("/events/{month}", response_model=EventsResponse)
 async def get_events(month: str):
     month_key = month.lower() if month else datetime.utcnow().strftime("%B").lower()
@@ -48,3 +59,8 @@ async def get_categories(category: str | None = None):
 @app.get("/design-ideas", response_model=list[DesignIdeaCategory])
 async def design_ideas(category: str | None = None):
     return get_design_ideas(category)
+
+
+@app.get("/suggestions", response_model=list[Suggestion])
+async def product_suggestions(category: str | None = None, design: str | None = None):
+    return get_product_suggestions(category, design)

--- a/services/trend_scraper/service.py
+++ b/services/trend_scraper/service.py
@@ -282,3 +282,43 @@ def get_design_ideas(category: str | None = None) -> List[dict]:
         {"name": name, "ideas": ideas}
         for name, ideas in FALLBACK_DESIGN_INSPIRATIONS.items()
     ]
+
+
+def get_product_suggestions(
+    category: str | None = None, design: str | None = None
+) -> List[dict]:
+    """Return combined product suggestions using categories and design themes."""
+
+    import random
+
+    categories = (
+        {category.lower(): FALLBACK_CATEGORIES.get(category.lower(), [])}
+        if category
+        else FALLBACK_CATEGORIES
+    )
+    designs = (
+        {design.lower(): FALLBACK_DESIGN_INSPIRATIONS.get(design.lower(), [])}
+        if design
+        else FALLBACK_DESIGN_INSPIRATIONS
+    )
+
+    suggestions: list[dict] = []
+    design_keys = list(designs.keys())
+
+    for cat_name, items in categories.items():
+        if not items or not design_keys:
+            continue
+        theme = random.choice(design_keys)
+        idea = random.choice(designs[theme])
+        item = random.choice(items)
+        suggestions.append(
+            {
+                "category": cat_name,
+                "design_theme": theme,
+                "suggestion": f"{idea} {item}",
+            }
+        )
+        if len(suggestions) >= 10:
+            break
+
+    return suggestions

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,18 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.gateway.api import app as gateway_app
+
+
+@pytest.mark.asyncio
+async def test_product_suggestions_endpoint():
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/product-suggestions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 5
+        for item in data:
+            assert "category" in item
+            assert "design_theme" in item
+            assert "suggestion" in item


### PR DESCRIPTION
## Summary
- add helper to generate combined product suggestions
- expose new `/suggestions` API in trend_scraper service
- proxy `/product-suggestions` through gateway
- add suggestions page in Next.js frontend
- link Suggestions in site navigation
- document new endpoint and page in README
- test product suggestions endpoint

## Testing
- `black . -q`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c75cc654832b867c95a82b5ed4ae