### PR TITLE
feat: add image review tool

### DIFF
--- a/client/components/StarRating.tsx
+++ b/client/components/StarRating.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export default function StarRating({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+  const [hover, setHover] = useState(0);
+  return (
+    <div className="flex space-x-1">
+      {[1, 2, 3, 4, 5].map(star => (
+        <svg
+          key={star}
+          onMouseEnter={() => setHover(star)}
+          onMouseLeave={() => setHover(0)}
+          onClick={() => onChange(star)}
+          data-testid={`star-${star}`}
+          xmlns="http://www.w3.org/2000/svg"
+          fill={(hover || value) >= star ? 'currentColor' : 'none'}
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="w-6 h-6 cursor-pointer"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 17.27L18.18 21 16.54 13.97 22 9.24 14.81 8.63 12 2 9.19 8.63 2 9.24 7.46 13.97 5.82 21 12 17.27z" />
+        </svg>
+      ))}
+    </div>
+  );
+}

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -16,5 +17,8 @@
     "postcss": "8.4.38",
     "autoprefixer": "10.4.17",
     "axios": "1.6.8"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.43.1"
   }
 }

--- a/client/pages/images/review.tsx
+++ b/client/pages/images/review.tsx
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import StarRating from '../../components/StarRating';
+import Layout from '../../components/Layout';
+
+interface Product {
+  id: number;
+  image_url: string;
+  rating?: number | null;
+  tags?: string | null;
+  flagged: boolean;
+}
+
+export default function ReviewPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await axios.get<Product[]>(`${api}/api/images/review`);
+      setProducts(res.data);
+    };
+    load();
+  }, [api]);
+
+  const update = async (p: Product) => {
+    await axios.post(`${api}/api/images/review/${p.id}`, {
+      rating: p.rating,
+      tags: p.tags ? p.tags.split(',').map(t => t.trim()) : [],
+      flagged: p.flagged,
+    });
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-4">Image Reviews</h1>
+      <div className="grid gap-4" data-testid="image-list">
+        {products.map(p => (
+          <div key={p.id} className="border p-4 flex gap-4 items-center">
+            <img src={p.image_url} alt="product" className="w-24 h-24 object-cover" />
+            <div className="flex-1 space-y-2">
+              <StarRating value={p.rating || 0} onChange={v => setProducts(ps => ps.map(pr => (pr.id === p.id ? { ...pr, rating: v } : pr)))} />
+              <input
+                type="text"
+                className="border p-1 w-full"
+                placeholder="tags comma separated"
+                value={p.tags || ''}
+                onChange={e => setProducts(ps => ps.map(pr => (pr.id === p.id ? { ...pr, tags: e.target.value } : pr)))}
+              />
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={p.flagged}
+                  onChange={e => setProducts(ps => ps.map(pr => (pr.id === p.id ? { ...pr, flagged: e.target.checked } : pr)))}
+                />
+                Flagged
+              </label>
+              <button className="bg-blue-600 text-white px-2 py-1" onClick={() => update(p)} data-testid="save-btn">
+                Save
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Layout>
+  );
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run dev --prefix client',
+    port: 3000,
+    timeout: 120 * 1000,
+  },
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+});

--- a/services/image_review/api.py
+++ b/services/image_review/api.py
@@ -1,0 +1,27 @@
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .service import list_reviews, update_review
+
+app = FastAPI()
+
+
+class ReviewUpdate(BaseModel):
+    rating: Optional[int] = None
+    tags: Optional[List[str]] = None
+    flagged: Optional[bool] = None
+
+
+@app.get("/images/review")
+async def get_reviews():
+    return await list_reviews()
+
+
+@app.post("/images/review/{product_id}")
+async def post_review(product_id: int, data: ReviewUpdate):
+    product = await update_review(product_id, data.rating, data.tags, data.flagged)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product

--- a/services/image_review/service.py
+++ b/services/image_review/service.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+from sqlmodel import select
+
+from ..models import Product
+from ..common.database import get_session
+
+
+async def list_reviews() -> List[Product]:
+    async with get_session() as session:
+        result = await session.exec(select(Product))
+        return result.all()
+
+
+async def update_review(
+    product_id: int,
+    rating: Optional[int] = None,
+    tags: Optional[List[str]] = None,
+    flagged: Optional[bool] = None,
+) -> Product | None:
+    async with get_session() as session:
+        product = await session.get(Product, product_id)
+        if not product:
+            return None
+        if rating is not None:
+            product.rating = rating
+        if tags is not None:
+            product.tags = ",".join(tags)
+        if flagged is not None:
+            product.flagged = flagged
+        session.add(product)
+        await session.commit()
+        await session.refresh(product)
+        return product

--- a/services/models.py
+++ b/services/models.py
@@ -22,6 +22,9 @@ class Product(SQLModel, table=True):
     idea_id: int
     image_url: str
     sku: Optional[str] = None
+    rating: Optional[int] = Field(default=None, ge=1, le=5)
+    tags: Optional[str] = None
+    flagged: bool = False
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 

--- a/tests/e2e/review.spec.ts
+++ b/tests/e2e/review.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('load review page and render list', async ({ page }) => {
+  await page.goto('/images/review');
+  await expect(page.getByTestId('image-list')).toBeVisible();
+});

--- a/tests/test_image_review.py
+++ b/tests/test_image_review.py
@@ -1,0 +1,40 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.image_review.api import app as review_app
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db
+from services.models import Product
+from services.common.database import get_session
+
+
+@pytest.mark.asyncio
+async def test_review_crud():
+    await init_db()
+    async with get_session() as session:
+        p = Product(idea_id=1, image_url="http://example.com/img.png")
+        session.add(p)
+        await session.commit()
+        await session.refresh(p)
+
+    transport = ASGITransport(app=review_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/images/review")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(item["id"] == p.id for item in data)
+
+        resp = await client.post(
+            f"/images/review/{p.id}",
+            json={"rating": 5, "tags": ["fun"], "flagged": False},
+        )
+        assert resp.status_code == 200
+        updated = resp.json()
+        assert updated["rating"] == 5
+        assert updated["tags"] == "fun"
+
+    g_transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=g_transport, base_url="http://test") as client:
+        resp = await client.get("/api/images/review")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(item["id"] == p.id and item["rating"] == 5 for item in data)


### PR DESCRIPTION
## Summary
- extend `Product` schema with rating, tags and flagged fields
- implement `image_review` service to manage image reviews
- expose image review endpoints via gateway
- add review UI in Next.js dashboard with star ratings
- configure Playwright and add basic e2e test
- cover review workflow with unit tests

## Testing
- `black services tests -q`
- `flake8`
- `pytest -q`
- `npx playwright test --reporter=list --workers=1 tests/e2e/review.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68818450fee8832b9f4fe1041332615b