### PR TITLE
Implement user quotas and display usage

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -8,7 +8,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     axios
-      .get(`${api}/user/plan`, { headers: { 'X-User-Id': '1' } })
+      .get(`${api}/api/user/plan`, { headers: { 'X-User-Id': '1' } })
       .then((res) => setUsage(res.data))
       .catch((err) => console.error(err));
   }, [api]);

--- a/services/common/quotas.py
+++ b/services/common/quotas.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+import json
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from .database import get_session
+from ..models import User
+
+PLAN_LIMITS = {"free": 20}
+
+async def quota_middleware(request: Request, call_next):
+    if request.url.path != "/images" or request.method.upper() != "POST":
+        return await call_next(request)
+
+    user_id = request.headers.get("X-User-Id")
+    if not user_id:
+        return JSONResponse({"detail": "Missing X-User-Id"}, status_code=400)
+
+    body_bytes = await request.body()
+    try:
+        payload = json.loads(body_bytes)
+        count = len(payload.get("ideas", []))
+    except Exception:
+        count = 1
+    request._body = body_bytes  # allow downstream handlers to read body again
+
+    async with get_session() as session:
+        user = await session.get(User, int(user_id))
+        now = datetime.utcnow()
+        if not user:
+            user = User(id=int(user_id), last_reset=now)
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+        else:
+            if user.last_reset.month != now.month or user.last_reset.year != now.year:
+                user.images_used = 0
+                user.last_reset = now
+                session.add(user)
+                await session.commit()
+
+        limit = PLAN_LIMITS.get(user.plan, PLAN_LIMITS["free"])
+        if user.images_used + count > limit:
+            return JSONResponse({"detail": "Image quota exceeded"}, status_code=402)
+
+        response = await call_next(request)
+        user.images_used += count
+        session.add(user)
+        await session.commit()
+        return response

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 from .service import generate_images
+from ..common.quotas import quota_middleware
 
 app = FastAPI()
+app.middleware("http")(quota_middleware)
 
 
 class IdeaList(BaseModel):

--- a/services/models.py
+++ b/services/models.py
@@ -30,3 +30,10 @@ class Listing(SQLModel, table=True):
     product_id: int
     etsy_url: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    plan: str = "free"
+    images_used: int = 0
+    last_reset: datetime = Field(default_factory=datetime.utcnow)

--- a/services/user/api.py
+++ b/services/user/api.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from fastapi import FastAPI, Header
+from ..common.database import get_session
+from ..models import User
+from ..common.quotas import PLAN_LIMITS
+
+app = FastAPI()
+
+
+@app.get("/user/plan")
+async def user_plan(x_user_id: str = Header(..., alias="X-User-Id")):
+    async with get_session() as session:
+        user = await session.get(User, int(x_user_id))
+        now = datetime.utcnow()
+        if not user:
+            user = User(id=int(x_user_id), last_reset=now)
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+        else:
+            if user.last_reset.month != now.month or user.last_reset.year != now.year:
+                user.images_used = 0
+                user.last_reset = now
+                session.add(user)
+                await session.commit()
+                await session.refresh(user)
+        limit = PLAN_LIMITS.get(user.plan, PLAN_LIMITS["free"])
+        return {"plan": user.plan, "images_used": user.images_used, "limit": limit}

--- a/tests/e2e/navbar.spec.ts
+++ b/tests/e2e/navbar.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('home page navbar shows links and quota', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Generate' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Categories' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Design Ideas' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Suggestions' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Analytics' })).toBeVisible();
+  await expect(page.getByTestId('quota')).toHaveCount(1);
+});

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.image_gen.api import app as image_app
+from services.common.database import init_db, get_session
+from services.models import User
+
+
+@pytest.mark.asyncio
+async def test_quota_enforcement():
+    await init_db()
+    async with get_session() as session:
+        existing = await session.get(User, 1)
+        if existing:
+            await session.delete(existing)
+            await session.commit()
+    transport = ASGITransport(app=image_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for i in range(21):
+            resp = await client.post(
+                "/images",
+                json={"ideas": ["idea"]},
+                headers={"X-User-Id": "1"},
+            )
+            if i < 20:
+                assert resp.status_code == 200
+            else:
+                assert resp.status_code == 402

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,25 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.user.api import app as user_app
+from services.common.database import init_db, get_session
+from services.common.quotas import PLAN_LIMITS
+from services.models import User
+
+
+@pytest.mark.asyncio
+async def test_user_plan_endpoint():
+    await init_db()
+    async with get_session() as session:
+        existing = await session.get(User, 1)
+        if existing:
+            await session.delete(existing)
+            await session.commit()
+    transport = ASGITransport(app=user_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/user/plan", headers={"X-User-Id": "1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["plan"] == "free"
+        assert data["images_used"] == 0
+        assert data["limit"] == PLAN_LIMITS["free"]
+        assert set(data.keys()) == {"plan", "images_used", "limit"}


### PR DESCRIPTION
## Summary
- add user quota middleware and model fields
- enforce quotas for image generation
- expose `/user/plan` API and fetch it in client layout
- show quota usage in navbar
- add unit tests and e2e test for quota display

## Testing
- `pytest -q`
- `NODE_PATH=client/node_modules npx --prefix client playwright test tests/e2e/navbar.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6885c6013234832bbdd7a4b15fe9b0b7