### PR TITLE
Update backlog in status.md

### DIFF
--- a/status.md
+++ b/status.md
@@ -15,8 +15,15 @@ This file tracks the remaining work required to bring PODPusher to production re
 4. **Listing Composer Enhancements** – Finalise the character-count and tag-suggestion features; ensure they are merged and tested.
 5. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
 6. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
-7. **Documentation** – Update internal docs and API docs as new features are added. Maintain architecture and schema diagrams.
-8. **Stub Removal** – Once integrations are tested, remove any placeholder or stubbed logic from the codebase.
+
+7. **Documentation** – Update internal docs and API docs as new features are added.
+8. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
+9. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
+10. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
+11. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+12. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
+13. Maintain architecture and schema diagrams.
+14. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
 
 ## Instructions to Agents
 


### PR DESCRIPTION
## Summary
- add backlog items for bulk product creation, search and filtering, A/B tests, notifications, and i18n
- move architecture diagram and stub removal bullets to end of list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885de940d50832b9a622405a76ab42f