### PR TITLE
Add notifications and scheduling system

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ mountain posters" or "paw print blankets" mixed with product types.
 ## Localization
 
 The dashboard is fully translated using `next-i18next`. Translation files are located in `client/locales/<lang>/common.json`. Use the language switcher in the navigation bar to change languages. To add a new locale, create a folder with translations matching the keys in the English file and update `client/next-i18next.config.js`.
+
+## Notifications & Scheduling
+
+The backend includes a notifications service with a background scheduler. Monthly jobs reset image quotas for all users and create a reminder notification. Weekly jobs send a trending keywords summary based on the latest scraped data. Visit `/notifications` in the dashboard to view and mark messages as read. Unread counts appear beside a bell icon in the navigation bar.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -7,12 +7,18 @@ import LanguageSwitcher from './LanguageSwitcher';
 export default function Layout({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common');
   const [usage, setUsage] = useState<{ plan: string; images_used: number; limit: number } | null>(null);
+  const [unread, setUnread] = useState(0);
   const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
   useEffect(() => {
     axios
       .get(`${api}/api/user/plan`, { headers: { 'X-User-Id': '1' } })
       .then((res) => setUsage(res.data))
+      .catch((err) => console.error(err));
+
+    axios
+      .get(`${api}/api/notifications`, { headers: { 'X-User-Id': '1' } })
+      .then((res) => setUnread(res.data.filter((n: any) => !n.read).length))
       .catch((err) => console.error(err));
   }, [api]);
 
@@ -27,6 +33,18 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <LanguageSwitcher />
+          <Link
+            href="/notifications"
+            aria-label={t('nav.notifications')}
+            className="relative flex items-center"
+          >
+            <span>🔔</span>
+            {unread > 0 && (
+              <span data-testid="unread-count" className="ml-1 text-xs bg-red-500 rounded-full px-1">
+                {unread}
+              </span>
+            )}
+          </Link>
           <span className="ml-auto text-sm" data-testid="quota">
             {usage ? `${usage.images_used}/${usage.limit} images` : ''}
           </span>

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -41,5 +41,9 @@
   "analytics": {
     "title": "Keyword Analytics",
     "revenue": "Revenue"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "markRead": "Mark as read"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -41,5 +41,9 @@
   "analytics": {
     "title": "Analítica de palabras clave",
     "revenue": "Ingresos"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "markRead": "Marcar como leído"
   }
 }

--- a/client/pages/notifications.tsx
+++ b/client/pages/notifications.tsx
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+export type Notification = {
+  id: number;
+  message: string;
+  created_at: string;
+  read: boolean;
+};
+
+export default function Notifications() {
+  const { t } = useTranslation('common');
+  const [items, setItems] = useState<Notification[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    axios
+      .get<Notification[]>(`${api}/api/notifications`, {
+        headers: { 'X-User-Id': '1' },
+      })
+      .then(res => setItems(res.data))
+      .catch(err => console.error(err));
+  }, [api]);
+
+  const markRead = async (id: number) => {
+    await axios.put(`${api}/api/notifications/${id}/read`);
+    setItems(items.map(n => (n.id === id ? { ...n, read: true } : n)));
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">{t('notifications.title')}</h1>
+      <ul className="space-y-2">
+        {items.map(n => (
+          <li
+            key={n.id}
+            className={`p-2 border rounded ${n.read ? 'opacity-50' : ''}`}
+          >
+            <div className="flex justify-between items-center">
+              <span>{n.message}</span>
+              {!n.read && (
+                <button
+                  data-testid={`read-${n.id}`}
+                  onClick={() => markRead(n.id)}
+                  className="text-sm text-blue-500"
+                >
+                  {t('notifications.markRead')}
+                </button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest-asyncio
 flake8
 black
 aiosqlite
+APScheduler

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -10,10 +10,12 @@ from ..ideation.service import generate_ideas
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
+from ..notifications.api import app as notifications_app
 from ..trend_scraper.events import EVENTS
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
+app.mount("/api/notifications", notifications_app)
 
 
 @app.post("/generate")

--- a/services/models.py
+++ b/services/models.py
@@ -41,3 +41,11 @@ class User(SQLModel, table=True):
     plan: str = "free"
     images_used: int = 0
     last_reset: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Notification(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int
+    message: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    read: bool = False

--- a/services/notifications/api.py
+++ b/services/notifications/api.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+from .service import (
+    list_notifications,
+    create_notification,
+    mark_read,
+    start_scheduler,
+)
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def start() -> None:
+    start_scheduler()
+
+
+class NotificationCreate(BaseModel):
+    message: str
+    user_id: int | None = None
+
+
+@app.get("/")
+async def get_notifications(x_user_id: str = Header(..., alias="X-User-Id")):
+    return await list_notifications(int(x_user_id))
+
+
+@app.post("/")
+async def create_notification_endpoint(
+    payload: NotificationCreate,
+    x_user_id: str = Header(None, alias="X-User-Id"),
+):
+    user_id = payload.user_id or int(x_user_id)
+    return await create_notification(user_id, payload.message)
+
+
+@app.put("/{notification_id}/read")
+async def mark_read_endpoint(notification_id: int):
+    notif = await mark_read(notification_id)
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return notif

--- a/services/notifications/service.py
+++ b/services/notifications/service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+from datetime import datetime
+import asyncio
+from typing import List, Optional
+
+from sqlmodel import select
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from ..common.database import get_session
+from ..models import Notification, User
+from ..trend_scraper.service import fetch_trends
+
+
+def _to_dict(notification: Notification) -> dict:
+    return {
+        "id": notification.id,
+        "user_id": notification.user_id,
+        "message": notification.message,
+        "created_at": notification.created_at.isoformat(),
+        "read": notification.read,
+    }
+
+
+async def create_notification(user_id: int, message: str) -> dict:
+    async with get_session() as session:
+        n = Notification(user_id=user_id, message=message)
+        session.add(n)
+        await session.commit()
+        await session.refresh(n)
+        return _to_dict(n)
+
+
+async def list_notifications(user_id: int) -> List[dict]:
+    async with get_session() as session:
+        result = await session.exec(
+            select(Notification)
+            .where(Notification.user_id == user_id)
+            .order_by(Notification.created_at.desc())
+        )
+        notifications = result.all()
+        return [_to_dict(n) for n in notifications]
+
+
+async def mark_read(notification_id: int) -> Optional[dict]:
+    async with get_session() as session:
+        notif = await session.get(Notification, notification_id)
+        if not notif:
+            return None
+        notif.read = True
+        session.add(notif)
+        await session.commit()
+        await session.refresh(notif)
+        return _to_dict(notif)
+
+
+async def reset_monthly_quotas() -> None:
+    now = datetime.utcnow()
+    async with get_session() as session:
+        result = await session.exec(select(User))
+        users = result.all()
+        ids = [u.id for u in users]
+        for u in users:
+            u.images_used = 0
+            u.last_reset = now
+            session.add(u)
+        await session.commit()
+    for uid in ids:
+        await create_notification(uid, "Monthly quota has been reset.")
+
+
+async def weekly_trending_summary() -> None:
+    trends = await fetch_trends()
+    summary = ", ".join(t["term"] for t in trends[:3])
+    async with get_session() as session:
+        result = await session.exec(select(User.id))
+        user_ids = result.all()
+    for uid in user_ids:
+        await create_notification(uid, f"Weekly trending keywords: {summary}")
+
+
+scheduler = AsyncIOScheduler()
+
+scheduler.add_job(
+    lambda: asyncio.create_task(reset_monthly_quotas()),
+    trigger="cron",
+    day=1,
+    hour=0,
+)
+
+scheduler.add_job(
+    lambda: asyncio.create_task(weekly_trending_summary()),
+    trigger="cron",
+    day_of_week="mon",
+    hour=0,
+)
+
+
+def start_scheduler() -> None:
+    if not scheduler.running:
+        scheduler.start()

--- a/tests/e2e/navbar.spec.ts
+++ b/tests/e2e/navbar.spec.ts
@@ -8,5 +8,6 @@ test('home page navbar shows links and quota', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Design Ideas' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Suggestions' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Analytics' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Notifications' })).toBeVisible();
   await expect(page.getByTestId('quota')).toHaveCount(1);
 });

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('notifications page lists items', async ({ page }) => {
+  await page.route('**/api/notifications', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 1, message: 'hello', read: false, created_at: '' }]),
+    });
+  });
+
+  await page.route('**/api/notifications/1/read', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 1, message: 'hello', read: true, created_at: '' }),
+    });
+  });
+
+  await page.goto('/notifications');
+  await expect(page.getByText('Notifications')).toBeVisible();
+  await expect(page.getByText('hello')).toBeVisible();
+  await page.getByTestId('read-1').click();
+});

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,54 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from services.notifications.api import app as notif_app
+from services.notifications.service import reset_monthly_quotas, weekly_trending_summary
+from services.common.database import init_db, get_session
+from services.models import User
+
+
+@pytest.mark.asyncio
+async def test_notification_crud():
+    await init_db()
+    transport = ASGITransport(app=notif_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/", json={"message": "hello"}, headers={"X-User-Id": "1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message"] == "hello"
+
+        resp = await client.get("/", headers={"X-User-Id": "1"})
+        assert resp.status_code == 200
+        notifs = resp.json()
+        assert len(notifs) == 1
+
+        resp = await client.put(f"/{data['id']}/read")
+        assert resp.status_code == 200
+        assert resp.json()["read"] is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_jobs(monkeypatch):
+    await init_db()
+    async with get_session() as session:
+        user = User(id=1, images_used=5)
+        session.add(user)
+        await session.commit()
+
+    async def fake_fetch_trends(category=None):
+        return [{"term": "foo", "category": "general"}]
+
+    monkeypatch.setattr("services.notifications.service.fetch_trends", fake_fetch_trends)
+
+    await reset_monthly_quotas()
+    async with get_session() as session:
+        user = await session.get(User, 1)
+        assert user.images_used == 0
+
+    await weekly_trending_summary()
+    transport = ASGITransport(app=notif_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/", headers={"X-User-Id": "1"})
+        messages = [n["message"] for n in resp.json()]
+        assert any("Weekly trending" in m for m in messages)
+        assert any("quota" in m for m in messages)


### PR DESCRIPTION
## Summary
- implement Notification model and service with scheduler
- expose notifications API and mount in gateway
- add notifications page in Next.js frontend
- show notification bell with unread count
- localize notification text
- document Notifications & Scheduling features
- add unit and e2e tests

## Testing
- `pytest -q`
- `npx playwright install --with-deps` *(fails: installation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6885fd5e7788832b9de959e80fec6c59