### PR TITLE
Add search service and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ The dashboard is fully translated using `next-i18next`. Translation files are lo
 ## Notifications & Scheduling
 
 The backend includes a notifications service with a background scheduler. Monthly jobs reset image quotas for all users and create a reminder notification. Weekly jobs send a trending keywords summary based on the latest scraped data. Visit `/notifications` in the dashboard to view and mark messages as read. Unread counts appear beside a bell icon in the navigation bar.
+
+## Search API
+Use `/api/search` to look up products by keyword, category, tag and rating. Example:
+```bash
+curl "http://localhost:8000/api/search?q=cat&category=animals&rating_min=4"
+```
+This returns a JSON response with matching products and total count.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -31,6 +31,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/categories" className="hover:underline">{t('nav.categories')}</Link>
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
+          <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <LanguageSwitcher />
           <Link

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -5,6 +5,7 @@
     "categories": "Categories",
     "designIdeas": "Design Ideas",
     "suggestions": "Suggestions",
+    "search": "Search",
     "analytics": "Analytics"
   },
   "index": {

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -5,6 +5,7 @@
     "categories": "Categorías",
     "designIdeas": "Ideas de diseño",
     "suggestions": "Sugerencias",
+    "search": "Buscar",
     "analytics": "Analíticas"
   },
   "index": {

--- a/client/pages/search.tsx
+++ b/client/pages/search.tsx
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+interface Product {
+  id: number;
+  name: string;
+  description: string;
+  category: string;
+  image_url: string;
+  rating: number | null;
+  tags: string[];
+}
+
+export default function Search() {
+  const [keyword, setKeyword] = useState('');
+  const [category, setCategory] = useState('');
+  const [tag, setTag] = useState('');
+  const [rating, setRating] = useState(0);
+  const [results, setResults] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    axios
+      .get<{ name: string }[]>(`${api}/product-categories`)
+      .then(res => setCategories(res.data.map(c => c.name)))
+      .catch(err => console.error(err));
+  }, [api]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await axios.get(`${api}/api/search`, {
+        params: {
+          q: keyword || undefined,
+          category: category || undefined,
+          tag: tag || undefined,
+          rating_min: rating || undefined,
+        },
+      });
+      setResults(res.data.items);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Search</h1>
+      <form onSubmit={submit} className="flex flex-wrap gap-2 items-end">
+        <input
+          type="text"
+          className="border p-2 flex-grow"
+          placeholder="Keyword"
+          value={keyword}
+          onChange={e => setKeyword(e.target.value)}
+        />
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="border p-2"
+        >
+          <option value="">All Categories</option>
+          {categories.map(c => (
+            <option key={c} value={c}>
+              {c.replace(/_/g, ' ')}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          className="border p-2"
+          placeholder="Tag"
+          value={tag}
+          onChange={e => setTag(e.target.value)}
+        />
+        <input
+          type="range"
+          min="0"
+          max="5"
+          value={rating}
+          onChange={e => setRating(Number(e.target.value))}
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Search
+        </button>
+      </form>
+      {loading && <p>Loading...</p>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {results.map(r => (
+          <div key={r.id} className="border p-4 rounded space-y-2">
+            <img src={r.image_url} alt={r.name} className="w-full h-auto" />
+            <h3 className="font-semibold">{r.name}</h3>
+            <p className="text-sm italic">{r.category}</p>
+            <p className="text-sm">{r.description}</p>
+            <p className="text-sm">Rating: {r.rating ?? 'N/A'}</p>
+            <div className="flex flex-wrap gap-1">
+              {r.tags.map(t => (
+                <span key={t} className="text-xs bg-gray-200 rounded px-1">
+                  {t}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/common/quotas.py
+++ b/services/common/quotas.py
@@ -7,6 +7,7 @@ from ..models import User
 
 PLAN_LIMITS = {"free": 20}
 
+
 async def quota_middleware(request: Request, call_next):
     if request.url.path != "/images" or request.method.upper() != "POST":
         return await call_next(request)

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -11,11 +11,13 @@ from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
 from ..notifications.api import app as notifications_app
+from ..search.api import app as search_app
 from ..trend_scraper.events import EVENTS
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
+app.mount("/api/search", search_app)
 
 
 @app.post("/generate")

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from .service import search_products
+
+app = FastAPI()
+
+
+@app.get("/")
+async def search(
+    q: str | None = None,
+    category: str | None = None,
+    tag: str | None = None,
+    rating_min: int | None = None,
+    offset: int = 0,
+    limit: int = 10,
+):
+    return await search_products(
+        q=q,
+        category=category,
+        tag=tag,
+        rating_min=rating_min,
+        offset=offset,
+        limit=limit,
+    )

--- a/services/search/service.py
+++ b/services/search/service.py
@@ -1,0 +1,60 @@
+from typing import List, Optional, Dict
+from sqlalchemy import or_, func
+from sqlmodel import select
+
+from ..models import Product, Idea, Trend
+from ..common.database import get_session
+
+
+async def search_products(
+    q: Optional[str] = None,
+    category: Optional[str] = None,
+    tag: Optional[str] = None,
+    rating_min: Optional[int] = None,
+    offset: int = 0,
+    limit: int = 10,
+) -> Dict[str, List[Dict]]:
+    """Search products with optional filters and pagination."""
+
+    async with get_session() as session:
+        stmt = (
+            select(Product, Idea, Trend)
+            .join(Idea, Product.idea_id == Idea.id)
+            .join(Trend, Idea.trend_id == Trend.id)
+        )
+
+        if q:
+            pattern = f"%{q.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(Idea.description).like(pattern),
+                    func.lower(Trend.term).like(pattern),
+                )
+            )
+        if category:
+            stmt = stmt.where(Trend.category == category)
+        if rating_min is not None:
+            stmt = stmt.where(Product.rating >= rating_min)
+
+        result = await session.exec(stmt)
+        rows = result.all()
+
+        if tag:
+            rows = [r for r in rows if tag in ((r[0].tags) or [])]
+
+        total = len(rows)
+        rows = rows[offset : offset + limit]
+
+        items = [
+            {
+                "id": p.id,
+                "name": f"Product {p.id}",
+                "description": idea.description,
+                "category": trend.category,
+                "image_url": p.image_url,
+                "rating": p.rating,
+                "tags": p.tags or [],
+            }
+            for p, idea, trend in rows
+        ]
+        return {"total": total, "items": items}

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+const result = {
+  total: 1,
+  items: [
+    {
+      id: 1,
+      name: 'Product 1',
+      description: 'Cute cat mug',
+      category: 'animals',
+      image_url: '/img.png',
+      rating: 5,
+      tags: ['cute'],
+    },
+  ],
+};
+
+test('search filters results', async ({ page }) => {
+  await page.route('**/api/search**', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+  });
+  await page.route('**/product-categories', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ name: 'animals' }]) });
+  });
+
+  await page.goto('/search');
+  await page.getByPlaceholder('Keyword').fill('cat');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByText('Cute cat mug')).toBeVisible();
+});

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 
 EN_FILE = Path('client/locales/en/common.json')

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -12,7 +12,11 @@ async def test_notification_crud():
     await init_db()
     transport = ASGITransport(app=notif_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/", json={"message": "hello"}, headers={"X-User-Id": "1"})
+        resp = await client.post(
+            "/",
+            json={"message": "hello"},
+            headers={"X-User-Id": "1"},
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data["message"] == "hello"
@@ -38,7 +42,10 @@ async def test_scheduler_jobs(monkeypatch):
     async def fake_fetch_trends(category=None):
         return [{"term": "foo", "category": "general"}]
 
-    monkeypatch.setattr("services.notifications.service.fetch_trends", fake_fetch_trends)
+    monkeypatch.setattr(
+        "services.notifications.service.fetch_trends",
+        fake_fetch_trends,
+    )
 
     await reset_monthly_quotas()
     async with get_session() as session:

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from httpx import AsyncClient, ASGITransport
 from services.image_gen.api import app as image_app

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -1,0 +1,32 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db, get_session
+from services.models import Trend, Idea, Product
+
+
+@pytest.mark.asyncio
+async def test_search_endpoint():
+    await init_db()
+    async with get_session() as session:
+        t = Trend(term="dog shirt", category="animals")
+        session.add(t)
+        await session.commit()
+        await session.refresh(t)
+        i = Idea(trend_id=t.id, description="Funny dog shirt")
+        session.add(i)
+        await session.commit()
+        await session.refresh(i)
+        p = Product(idea_id=i.id, image_url="url", rating=4, tags=["funny"])
+        session.add(p)
+        await session.commit()
+        await session.refresh(p)
+        p_id = p.id
+
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/search/", params={"q": "dog", "rating_min": 4})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["id"] == p_id

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,0 +1,26 @@
+import pytest
+from services.search.service import search_products
+from services.common.database import init_db, get_session
+from services.models import Trend, Idea, Product
+
+
+@pytest.mark.asyncio
+async def test_search_products():
+    await init_db()
+    async with get_session() as session:
+        trend = Trend(term="cat mug", category="animals")
+        session.add(trend)
+        await session.commit()
+        await session.refresh(trend)
+        idea = Idea(trend_id=trend.id, description="Cute cat mug")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        prod = Product(idea_id=idea.id, image_url="url", rating=5, tags=["cute"])
+        session.add(prod)
+        await session.commit()
+        await session.refresh(prod)
+        prod_id = prod.id
+    res = await search_products(q="cat", category="animals", rating_min=4)
+    assert res["total"] == 1
+    assert res["items"][0]["id"] == prod_id


### PR DESCRIPTION
## Summary
- implement advanced search service with DB filters
- expose `/api/search` through gateway
- add search page and navbar link
- localize search navigation
- document Search API usage
- add unit, API and Playwright tests

## Testing
- `flake8`
- `pytest -q`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688608014288832bab405ea7837739e7