### PR TITLE
Implement advanced search v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,12 @@ The dashboard is fully translated using `next-i18next`. Translation files are lo
 ## Notifications & Scheduling
 
 The backend includes a notifications service with a background scheduler. Monthly jobs reset image quotas for all users and create a reminder notification. Weekly jobs send a trending keywords summary based on the latest scraped data. Visit `/notifications` in the dashboard to view and mark messages as read. Unread counts appear beside a bell icon in the navigation bar.
+
+## Search API
+
+Filter products using the `/api/search` endpoint. You can pass `q`, `category`,
+`tag` and `rating_min` query parameters. Example:
+
+```bash
+curl "http://localhost:8000/api/search?q=dog&category=apparel&tag=funny&rating_min=3"
+```

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -31,6 +31,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/categories" className="hover:underline">{t('nav.categories')}</Link>
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
+          <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <LanguageSwitcher />
           <Link

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -5,6 +5,7 @@
     "categories": "Categories",
     "designIdeas": "Design Ideas",
     "suggestions": "Suggestions",
+    "search": "Search",
     "analytics": "Analytics"
   },
   "index": {

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -5,6 +5,7 @@
     "categories": "Categorías",
     "designIdeas": "Ideas de diseño",
     "suggestions": "Sugerencias",
+    "search": "Buscar",
     "analytics": "Analíticas"
   },
   "index": {

--- a/client/pages/search.tsx
+++ b/client/pages/search.tsx
@@ -1,0 +1,116 @@
+import axios from 'axios';
+import { GetServerSideProps } from 'next';
+import { useState } from 'react';
+
+interface SearchResult {
+  id: number;
+  name: string;
+  description: string;
+  image_url: string;
+  rating: number | null;
+  tags: string[];
+  category: string;
+}
+
+interface SearchProps {
+  categories: string[];
+}
+
+export default function SearchPage({ categories }: SearchProps) {
+  const [q, setQ] = useState('');
+  const [category, setCategory] = useState('');
+  const [tag, setTag] = useState('');
+  const [rating, setRating] = useState(0);
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await axios.get<SearchResult[]>(`${api}/api/search`, {
+        params: {
+          q: q || undefined,
+          category: category || undefined,
+          tag: tag || undefined,
+          rating_min: rating || undefined,
+        },
+      });
+      setResults(res.data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">Search</h1>
+      <form onSubmit={submit} className="flex flex-wrap gap-2 items-end">
+        <input
+          className="border p-2 flex-grow"
+          placeholder="Keyword"
+          value={q}
+          onChange={e => setQ(e.target.value)}
+        />
+        <select
+          value={category}
+          onChange={e => setCategory(e.target.value)}
+          className="border p-2"
+        >
+          <option value="">All Categories</option>
+          {categories.map(c => (
+            <option key={c} value={c}>
+              {c.replace(/_/g, ' ')}
+            </option>
+          ))}
+        </select>
+        <input
+          className="border p-2"
+          placeholder="Tag"
+          value={tag}
+          onChange={e => setTag(e.target.value)}
+        />
+        <div className="flex flex-col items-start">
+          <label className="text-sm">Rating</label>
+          <input
+            type="range"
+            min="0"
+            max="5"
+            value={rating}
+            onChange={e => setRating(parseInt(e.target.value, 10))}
+          />
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Search
+        </button>
+      </form>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {results.map(r => (
+            <div key={r.id} className="border p-2 rounded">
+              <img src={r.image_url} alt={r.name} className="w-full h-32 object-cover mb-2" />
+              <h3 className="font-semibold">{r.name}</h3>
+              {r.rating && <p className="text-sm">Rating: {r.rating}</p>}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<SearchProps> = async () => {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  try {
+    const res = await axios.get<{ name: string }[]>(`${api}/product-categories`);
+    return { props: { categories: res.data.map(c => c.name) } };
+  } catch (err) {
+    console.error(err);
+    return { props: { categories: [] } };
+  }
+};

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -11,11 +11,13 @@ from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
 from ..notifications.api import app as notifications_app
+from ..search.api import app as search_app
 from ..trend_scraper.events import EVENTS
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
+app.mount("/api/search", search_app)
 
 
 @app.post("/generate")

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+from .service import search_products
+
+app = FastAPI()
+
+
+@app.get("/")
+async def search(
+    q: str | None = None,
+    category: str | None = None,
+    tag: str | None = None,
+    rating_min: int | None = None,
+    page: int = 1,
+    page_size: int = 10,
+):
+    return await search_products(
+        q=q,
+        category=category,
+        tag=tag,
+        rating_min=rating_min,
+        page=page,
+        page_size=page_size,
+    )

--- a/services/search/service.py
+++ b/services/search/service.py
@@ -1,0 +1,56 @@
+from typing import List, Optional
+from sqlmodel import select
+
+from ..models import Product, Idea, Trend
+from ..common.database import get_session
+
+
+async def search_products(
+    q: Optional[str] = None,
+    category: Optional[str] = None,
+    tag: Optional[str] = None,
+    rating_min: Optional[int] = None,
+    page: int = 1,
+    page_size: int = 10,
+) -> List[dict]:
+    """Filter products by keyword, category, tag and rating."""
+    async with get_session() as session:
+        stmt = (
+            select(Product, Idea, Trend)
+            .join(Idea, Product.idea_id == Idea.id)
+            .join(Trend, Idea.trend_id == Trend.id)
+        )
+        if rating_min is not None:
+            stmt = stmt.where(Product.rating >= rating_min)
+        result = await session.exec(stmt)
+        rows = result.all()
+
+    items: List[dict] = []
+    for product, idea, trend in rows:
+        if q:
+            q_lower = q.lower()
+            if q_lower not in (idea.description or "").lower() and q_lower not in (
+                trend.term or ""
+            ).lower():
+                continue
+        if category and trend.category != category.lower():
+            continue
+        if tag:
+            tags = [t.lower() for t in (product.tags or [])]
+            if tag.lower() not in tags:
+                continue
+        items.append(
+            {
+                "id": product.id,
+                "name": f"Product {product.id}",
+                "description": idea.description,
+                "image_url": product.image_url,
+                "rating": product.rating,
+                "tags": product.tags or [],
+                "category": trend.category,
+            }
+        )
+
+    start = (page - 1) * page_size
+    end = start + page_size
+    return items[start:end]

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('search page filters products', async ({ page }) => {
+  await page.route('**/product-categories', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ name: 'apparel' }]),
+    });
+  });
+
+  await page.route('**/api/search**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 1,
+          name: 'Product 1',
+          description: 'funny dog shirt',
+          image_url: '/test.png',
+          rating: 4,
+          tags: ['funny'],
+          category: 'apparel',
+        },
+      ]),
+    });
+  });
+
+  await page.goto('/search');
+  await page.getByPlaceholder('Keyword').fill('dog');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByText('Product 1')).toBeVisible();
+});

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -1,0 +1,39 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db, get_session
+from services.models import Trend, Idea, Product
+
+
+@pytest.mark.asyncio
+async def test_search_api_endpoint():
+    await init_db()
+    async with get_session() as session:
+        t = Trend(term="cat mug", category="accessories")
+        session.add(t)
+        await session.commit()
+        await session.refresh(t)
+        idea = Idea(trend_id=t.id, description="cute cat mug")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        prod = Product(
+            idea_id=idea.id,
+            image_url="img.png",
+            rating=5,
+            tags=["cute"],
+        )
+        session.add(prod)
+        await session.commit()
+
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/search/",
+            params={"q": "cat", "category": "accessories", "tag": "cute", "rating_min": 4},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["image_url"] == "img.png"

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,0 +1,32 @@
+import pytest
+
+from services.search.service import search_products
+from services.common.database import init_db, get_session
+from services.models import Trend, Idea, Product
+
+
+@pytest.mark.asyncio
+async def test_search_service_filters():
+    await init_db()
+    async with get_session() as session:
+        trend = Trend(term="dog", category="apparel")
+        session.add(trend)
+        await session.commit()
+        await session.refresh(trend)
+        idea = Idea(trend_id=trend.id, description="funny dog shirt")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        product = Product(
+            idea_id=idea.id,
+            image_url="x.png",
+            rating=4,
+            tags=["funny", "dog"],
+        )
+        session.add(product)
+        await session.commit()
+        await session.refresh(product)
+
+    results = await search_products(q="dog", category="apparel", tag="funny", rating_min=3)
+    assert len(results) == 1
+    assert results[0]["id"] == product.id


### PR DESCRIPTION
## Summary
- add SQLModel-powered search service with API
- expose search endpoints through gateway
- create search page in Next.js dashboard
- update navigation and translations
- document search API usage
- test search service, API and UI

## Testing
- `flake8`
- `pytest -q`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688608014288832bab405ea7837739e7