### PR TITLE
Implement A/B testing service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ The dashboard is fully translated using `next-i18next`. Translation files are lo
 ## Notifications & Scheduling
 
 The backend includes a notifications service with a background scheduler. Monthly jobs reset image quotas for all users and create a reminder notification. Weekly jobs send a trending keywords summary based on the latest scraped data. Visit `/notifications` in the dashboard to view and mark messages as read. Unread counts appear beside a bell icon in the navigation bar.
+
+## A/B Testing
+Create a test by visiting `/ab-tests` on the dashboard. Enter the title, description and tags for two variants. After submission the test ID and metrics are displayed. Click the variant buttons to simulate clicks and watch the conversion rate update.
+

--- a/client/__tests__/smoke.test.js
+++ b/client/__tests__/smoke.test.js
@@ -1,0 +1,5 @@
+const { test, expect } = require('@jest/globals');
+
+test('smoke', () => {
+  expect(1).toBe(1);
+});

--- a/client/pages/ab-tests.tsx
+++ b/client/pages/ab-tests.tsx
@@ -1,0 +1,145 @@
+import axios from 'axios';
+import { useState } from 'react';
+
+export type Metric = {
+  variant_name: string;
+  impressions: number;
+  clicks: number;
+  conversion_rate: number;
+};
+
+export default function AbTests() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [variantA, setVariantA] = useState('');
+  const [variantB, setVariantB] = useState('');
+  const [tagsA, setTagsA] = useState('');
+  const [tagsB, setTagsB] = useState('');
+  const [testId, setTestId] = useState<number | null>(null);
+  const [metrics, setMetrics] = useState<Metric[] | null>(null);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const fetchMetrics = async (id: number) => {
+    const res = await axios.get<Metric[]>(`${api}/ab_tests/${id}`);
+    setMetrics(res.data);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await axios.post<{ id: number }>(`${api}/ab_tests`, {
+      title,
+      description,
+      variant_a: variantA,
+      variant_b: variantB,
+      tags_a: tagsA.split(',').map(t => t.trim()).filter(Boolean),
+      tags_b: tagsB.split(',').map(t => t.trim()).filter(Boolean),
+    });
+    setTestId(res.data.id);
+    fetchMetrics(res.data.id);
+  };
+
+  const clickVariant = async (name: string) => {
+    if (!testId) return;
+    await axios.post(`${api}/ab_tests/${testId}/record_click`, null, {
+      params: { variant: name },
+    });
+    fetchMetrics(testId);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">A/B Tests</h1>
+      <form onSubmit={submit} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Title"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <textarea
+          className="border p-2 w-full"
+          placeholder="Description"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+        <div className="flex flex-col sm:flex-row gap-2">
+          <div className="flex-1 space-y-1">
+            <input
+              className="border p-2 w-full"
+              placeholder="Variant A"
+              value={variantA}
+              onChange={e => setVariantA(e.target.value)}
+            />
+            <input
+              className="border p-2 w-full"
+              placeholder="Tags A comma separated"
+              value={tagsA}
+              onChange={e => setTagsA(e.target.value)}
+            />
+          </div>
+          <div className="flex-1 space-y-1">
+            <input
+              className="border p-2 w-full"
+              placeholder="Variant B"
+              value={variantB}
+              onChange={e => setVariantB(e.target.value)}
+            />
+            <input
+              className="border p-2 w-full"
+              placeholder="Tags B comma separated"
+              value={tagsB}
+              onChange={e => setTagsB(e.target.value)}
+            />
+          </div>
+        </div>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Create Test
+        </button>
+      </form>
+      {testId && (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Test ID: {testId}</h2>
+          {metrics && (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="px-2">Variant</th>
+                  <th className="px-2">Impressions</th>
+                  <th className="px-2">Clicks</th>
+                  <th className="px-2">Conversion</th>
+                </tr>
+              </thead>
+              <tbody>
+                {metrics.map(m => (
+                  <tr key={m.variant_name} className="text-center">
+                    <td className="border px-2 py-1">{m.variant_name}</td>
+                    <td className="border px-2 py-1">{m.impressions}</td>
+                    <td className="border px-2 py-1">{m.clicks}</td>
+                    <td className="border px-2 py-1">
+                      {(m.conversion_rate * 100).toFixed(1)}%
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          <div className="space-x-2">
+            <button
+              onClick={() => clickVariant(variantA)}
+              className="px-3 py-1 bg-green-600 text-white"
+            >
+              Click {variantA}
+            </button>
+            <button
+              onClick={() => clickVariant(variantB)}
+              className="px-3 py-1 bg-green-600 text-white"
+            >
+              Click {variantB}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/services/ab_test/api.py
+++ b/services/ab_test/api.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .service import create_test, get_metrics, record_click, record_impression
+
+app = FastAPI()
+
+
+class VariantInput(BaseModel):
+    title: str
+    description: str
+    variant_a: str
+    variant_b: str
+    tags_a: list[str] | None = None
+    tags_b: list[str] | None = None
+
+
+@app.post("/api/ab_tests")
+async def create_ab_test(payload: VariantInput):
+    test_id = await create_test(
+        payload.title,
+        payload.description,
+        payload.variant_a,
+        payload.variant_b,
+        payload.tags_a,
+        payload.tags_b,
+    )
+    return {"id": test_id}
+
+
+@app.get("/api/ab_tests/{test_id}")
+async def get_ab_test_metrics(test_id: int):
+    return await get_metrics(test_id)
+
+
+@app.post("/api/ab_tests/{test_id}/record_click")
+async def record_click_endpoint(test_id: int, variant: str):
+    await record_click(test_id, variant)
+    return {"status": "ok"}
+
+
+@app.post("/api/ab_tests/{test_id}/record_impression")
+async def record_impression_endpoint(test_id: int, variant: str):
+    await record_impression(test_id, variant)
+    return {"status": "ok"}

--- a/services/ab_test/service.py
+++ b/services/ab_test/service.py
@@ -1,0 +1,77 @@
+from typing import List, Optional
+from sqlmodel import select
+
+from ..common.database import get_session
+from ..models import ABTest, ABVariant
+
+
+async def create_test(
+    title: str,
+    description: str,
+    variant_a: str,
+    variant_b: str,
+    tags_a: Optional[List[str]] = None,
+    tags_b: Optional[List[str]] = None,
+) -> int:
+    """Create a new A/B test with two variants."""
+    async with get_session() as session:
+        test = ABTest(title=title, description=description)
+        session.add(test)
+        await session.commit()
+        await session.refresh(test)
+        test_id = test.id
+        session.add(ABVariant(test_id=test_id, variant_name=variant_a, tags=tags_a))
+        session.add(ABVariant(test_id=test_id, variant_name=variant_b, tags=tags_b))
+        await session.commit()
+        return test_id
+
+
+async def get_metrics(test_id: int) -> List[dict]:
+    """Return metrics per variant."""
+    async with get_session() as session:
+        result = await session.exec(
+            select(ABVariant).where(ABVariant.test_id == test_id)
+        )
+        variants = result.all()
+        metrics = []
+        for v in variants:
+            conversion = v.clicks / v.impressions if v.impressions else 0.0
+            metrics.append(
+                {
+                    "variant_name": v.variant_name,
+                    "impressions": v.impressions,
+                    "clicks": v.clicks,
+                    "conversion_rate": conversion,
+                }
+            )
+        return metrics
+
+
+async def record_click(test_id: int, variant_name: str) -> None:
+    """Increment click count for a variant."""
+    async with get_session() as session:
+        result = await session.exec(
+            select(ABVariant).where(
+                ABVariant.test_id == test_id, ABVariant.variant_name == variant_name
+            )
+        )
+        variant = result.one_or_none()
+        if variant:
+            variant.clicks += 1
+            session.add(variant)
+            await session.commit()
+
+
+async def record_impression(test_id: int, variant_name: str) -> None:
+    """Increment impression count for a variant."""
+    async with get_session() as session:
+        result = await session.exec(
+            select(ABVariant).where(
+                ABVariant.test_id == test_id, ABVariant.variant_name == variant_name
+            )
+        )
+        variant = result.one_or_none()
+        if variant:
+            variant.impressions += 1
+            session.add(variant)
+            await session.commit()

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -11,11 +11,13 @@ from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
 from ..notifications.api import app as notifications_app
+from ..ab_test.api import app as ab_test_app
 from ..trend_scraper.events import EVENTS
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
+app.mount("/ab_tests", ab_test_app)
 
 
 @app.post("/generate")

--- a/services/models.py
+++ b/services/models.py
@@ -49,3 +49,20 @@ class Notification(SQLModel, table=True):
     message: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
     read: bool = False
+
+
+class ABTest(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    description: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ABVariant(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    test_id: int = Field(foreign_key="abtest.id")
+    variant_name: str
+    tags: list[str] | None = Field(default=None, sa_column=Column(JSON))
+    impressions: int = 0
+    clicks: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/tests/e2e/ab-tests.spec.ts
+++ b/tests/e2e/ab-tests.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test('ab test page creates test', async ({ page }) => {
+  await page.route('**/ab_tests', route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1 }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { variant_name: 'A', impressions: 0, clicks: 0, conversion_rate: 0 },
+          { variant_name: 'B', impressions: 0, clicks: 0, conversion_rate: 0 },
+        ]),
+      });
+    }
+  });
+
+  await page.goto('/ab-tests');
+  await page.getByPlaceholder('Title').fill('My Test');
+  await page.getByPlaceholder('Variant A').fill('A');
+  await page.getByPlaceholder('Variant B').fill('B');
+  await page.getByRole('button', { name: 'Create Test' }).click();
+  await expect(page.getByText('Test ID:')).toBeVisible();
+});

--- a/tests/test_ab_test_api.py
+++ b/tests/test_ab_test_api.py
@@ -1,0 +1,30 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.ab_test.api import app as ab_app
+from services.common.database import init_db
+
+
+@pytest.mark.asyncio
+async def test_ab_test_api_flow():
+    await init_db()
+    transport = ASGITransport(app=ab_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/ab_tests",
+            json={
+                "title": "T",
+                "description": "D",
+                "variant_a": "A",
+                "variant_b": "B",
+            },
+        )
+        assert resp.status_code == 200
+        test_id = resp.json()["id"]
+        resp = await client.post(
+            f"/api/ab_tests/{test_id}/record_click",
+            params={"variant": "A"},
+        )
+        assert resp.status_code == 200
+        resp = await client.get(f"/api/ab_tests/{test_id}")
+        data = resp.json()
+        assert any(m["clicks"] == 1 for m in data)

--- a/tests/test_ab_test_service.py
+++ b/tests/test_ab_test_service.py
@@ -1,0 +1,30 @@
+import pytest
+from services.ab_test.service import (
+    create_test,
+    get_metrics,
+    record_click,
+    record_impression,
+)
+from services.common.database import init_db
+
+
+@pytest.mark.asyncio
+async def test_ab_test_metrics():
+    await init_db()
+    test_id = await create_test(
+        "Title",
+        "Desc",
+        "A",
+        "B",
+        ["t1"],
+        ["t2"],
+    )
+    metrics = await get_metrics(test_id)
+    assert len(metrics) == 2
+    await record_impression(test_id, "A")
+    await record_click(test_id, "A")
+    metrics = await get_metrics(test_id)
+    a = next(m for m in metrics if m["variant_name"] == "A")
+    assert a["impressions"] == 1
+    assert a["clicks"] == 1
+    assert a["conversion_rate"] == 1.0

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 
 EN_FILE = Path('client/locales/en/common.json')

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from httpx import AsyncClient, ASGITransport
 from services.image_gen.api import app as image_app


### PR DESCRIPTION
## Summary
- add ABTest and ABVariant models
- create ab_test service and API
- mount ab_test in gateway API
- add frontend page for creating and viewing AB tests
- document A/B testing in README
- add unit tests and e2e test

## Testing
- `flake8`
- `pytest -q`
- `npm test`
- `npx playwright test tests/e2e/ab-tests.spec.ts` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6886060a67dc832b83db38aa05402a04