### PR TITLE
Add listing composer with tag suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ The dashboard is fully translated using `next-i18next`. Translation files are lo
 ## Notifications & Scheduling
 
 The backend includes a notifications service with a background scheduler. Monthly jobs reset image quotas for all users and create a reminder notification. Weekly jobs send a trending keywords summary based on the latest scraped data. Visit `/notifications` in the dashboard to view and mark messages as read. Unread counts appear beside a bell icon in the navigation bar.
+
+## Listing Composer
+
+The `/listings` page now features a rich listing composer. It displays live character counts for the title and description fields and can generate tag suggestions using the new `/suggest-tags` endpoint. Click **Suggest Tags** to automatically populate recommended search tags based on your description.

--- a/client/__tests__/ListingComposer.test.tsx
+++ b/client/__tests__/ListingComposer.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import ListingComposer from '../components/ListingComposer';
+
+jest.mock('axios');
+const mocked = axios as jest.Mocked<typeof axios>;
+
+describe('ListingComposer', () => {
+  it('shows character counts and suggests tags', async () => {
+    mocked.post.mockResolvedValue({ data: ['foo', 'bar'] });
+    render(<ListingComposer />);
+    const title = screen.getByTestId('title-input');
+    fireEvent.change(title, { target: { value: 'Hello' } });
+    expect(screen.getByText(/5\/140/)).toBeInTheDocument();
+    const desc = screen.getByTestId('description-input');
+    fireEvent.change(desc, { target: { value: 'Description here' } });
+    expect(screen.getByText(/16\/2000/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('suggest-button'));
+    await waitFor(() => expect(mocked.post).toHaveBeenCalled());
+    expect((screen.getByTestId('tags-input') as HTMLInputElement).value).toBe('foo, bar');
+  });
+});

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -31,6 +31,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/categories" className="hover:underline">{t('nav.categories')}</Link>
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
+          <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <LanguageSwitcher />
           <Link

--- a/client/components/ListingComposer.tsx
+++ b/client/components/ListingComposer.tsx
@@ -1,0 +1,75 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+export default function ListingComposer() {
+  const { t } = useTranslation('common');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const [loading, setLoading] = useState(false);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const suggestTags = async () => {
+    setLoading(true);
+    try {
+      const res = await axios.post<string[]>(`${api}/suggest-tags`, {
+        description,
+      });
+      setTags(res.data.join(', '));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium">
+          {t('listings.titleLabel')} ({title.length}/140 {t('listings.characters')})
+        </label>
+        <input
+          data-testid="title-input"
+          type="text"
+          className="border p-2 w-full"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">
+          {t('listings.descriptionLabel')} ({description.length}/2000 {t('listings.characters')})
+        </label>
+        <textarea
+          data-testid="description-input"
+          className="border p-2 w-full"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium" htmlFor="tags">
+          {t('listings.tagsLabel')}
+        </label>
+        <input
+          id="tags"
+          data-testid="tags-input"
+          type="text"
+          className="border p-2 w-full"
+          value={tags}
+          onChange={e => setTags(e.target.value)}
+        />
+        <button
+          type="button"
+          data-testid="suggest-button"
+          onClick={suggestTags}
+          className="mt-2 bg-blue-600 text-white px-4 py-1"
+        >
+          {loading ? '...' : t('listings.suggest')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'ts-jest/presets/js-with-ts',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.test.ts?(x)'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      { useESM: true, tsconfig: { jsx: 'react-jsx' } },
+    ],
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+};

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -5,7 +5,8 @@
     "categories": "Categories",
     "designIdeas": "Design Ideas",
     "suggestions": "Suggestions",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "listings": "Listings"
   },
   "index": {
     "trending": "Trending Keywords",
@@ -45,5 +46,13 @@
   "notifications": {
     "title": "Notifications",
     "markRead": "Mark as read"
+  },
+  "listings": {
+    "title": "Listing Composer",
+    "titleLabel": "Title",
+    "descriptionLabel": "Description",
+    "tagsLabel": "Tags",
+    "suggest": "Suggest Tags",
+    "characters": "characters"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -5,7 +5,8 @@
     "categories": "Categorías",
     "designIdeas": "Ideas de diseño",
     "suggestions": "Sugerencias",
-    "analytics": "Analíticas"
+    "analytics": "Analíticas",
+    "listings": "Listados"
   },
   "index": {
     "trending": "Palabras clave en tendencia",
@@ -45,5 +46,13 @@
   "notifications": {
     "title": "Notificaciones",
     "markRead": "Marcar como leído"
+  },
+  "listings": {
+    "title": "Compositor de listado",
+    "titleLabel": "Título",
+    "descriptionLabel": "Descripción",
+    "tagsLabel": "Etiquetas",
+    "suggest": "Sugerir etiquetas",
+    "characters": "caracteres"
   }
 }

--- a/client/pages/listings.tsx
+++ b/client/pages/listings.tsx
@@ -1,0 +1,12 @@
+import ListingComposer from '../components/ListingComposer';
+import { useTranslation } from 'next-i18next';
+
+export default function Listings() {
+  const { t } = useTranslation('common');
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">{t('listings.title')}</h1>
+      <ListingComposer />
+    </div>
+  );
+}

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -6,7 +6,7 @@ from ..trend_scraper.service import (
     get_design_ideas,
     get_product_suggestions,
 )
-from ..ideation.service import generate_ideas
+from ..ideation.service import generate_ideas, suggest_tags
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
@@ -45,3 +45,9 @@ async def design_ideas(category: str | None = None):
 @app.get("/product-suggestions")
 async def product_suggestions(category: str | None = None, design: str | None = None):
     return get_product_suggestions(category, design)
+
+
+@app.post("/suggest-tags")
+async def gateway_suggest_tags(payload: dict):
+    description = payload.get("description", "")
+    return await suggest_tags(description)

--- a/services/ideation/api.py
+++ b/services/ideation/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import generate_ideas
+from .service import generate_ideas, suggest_tags
 
 app = FastAPI()
 
@@ -9,6 +9,15 @@ class TrendList(BaseModel):
     trends: list[str]
 
 
+class DescriptionPayload(BaseModel):
+    description: str
+
+
 @app.post("/ideas")
 async def ideas(data: TrendList):
     return await generate_ideas(data.trends)
+
+
+@app.post("/suggest-tags")
+async def suggest_tags_endpoint(data: DescriptionPayload):
+    return await suggest_tags(data.description)

--- a/services/ideation/service.py
+++ b/services/ideation/service.py
@@ -64,3 +64,31 @@ async def generate_ideas(trends: List[TrendInput]) -> List[Dict]:
                 {"description": idea.description, "term": term, "category": cat}
             )
     return ideas
+
+
+async def suggest_tags(description: str) -> List[str]:
+    key = os.getenv("OPENAI_API_KEY")
+    if key:
+        try:
+            import openai
+
+            resp = await openai.ChatCompletion.acreate(
+                model="gpt-4o",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": (
+                            "Suggest Etsy listing tags as a JSON array for: "
+                            f"{description}"
+                        ),
+                    }
+                ],
+            )
+            import json
+
+            tags = json.loads(resp.choices[0].message.content)
+            if isinstance(tags, list):
+                return [str(t) for t in tags]
+        except Exception:
+            pass
+    return description.lower().split()[:5]

--- a/tests/e2e/listings.spec.ts
+++ b/tests/e2e/listings.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('listing composer counts and suggests tags', async ({ page }) => {
+  await page.route('**/suggest-tags', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['foo', 'bar']),
+    });
+  });
+
+  await page.goto('/listings');
+  await expect(page.getByText('Listing Composer')).toBeVisible();
+  const title = page.getByTestId('title-input');
+  await title.fill('Hello');
+  await expect(page.getByText('5/140')).toBeVisible();
+  await page.getByTestId('suggest-button').click();
+  await expect(page.getByTestId('tags-input')).toHaveValue('foo, bar');
+});

--- a/tests/test_suggest_tags.py
+++ b/tests/test_suggest_tags.py
@@ -1,0 +1,31 @@
+import json
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.ideation.api import app as ideation_app
+from services.gateway.api import app as gateway_app
+
+
+@pytest.mark.asyncio
+async def test_suggest_tags_endpoint(monkeypatch):
+    async def fake_acreate(**kwargs):
+        class R:
+            choices = [type('C', (), {'message': type('M', (), {'content': json.dumps(["tag1", "tag2"])})})]
+        return R()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+    monkeypatch.setattr("openai.ChatCompletion.acreate", fake_acreate)
+    transport = ASGITransport(app=ideation_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/suggest-tags", json={"description": "foo"})
+        assert resp.status_code == 200
+        assert resp.json() == ["tag1", "tag2"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_suggest_tags():
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/suggest-tags", json={"description": "hello world"})
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+        assert resp.json()


### PR DESCRIPTION
## Summary
- add listing composer component with character counts and tag suggestions
- implement `/suggest-tags` endpoint in ideation service and expose via gateway
- add Next.js `/listings` page using the new component
- extend translations and navigation
- include unit and e2e tests
- document feature in README

## Testing
- `npm test --silent`
- `pytest -q`
- `npx --prefix client playwright test tests/e2e/listings.spec.ts --workers=1 --reporter=line` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68860996dfe0832b9e357c5ae445768e