### PR TITLE
Add A/B testing support v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,18 @@ Filter products using the `/api/search` endpoint. You can pass `q`, `category`,
 ```bash
 curl "http://localhost:8000/api/search?q=dog&category=apparel&tag=funny&rating_min=3"
 ```
+
+## A/B Testing
+
+Create experiments using the `/ab_tests` API. Post a JSON payload with a test
+name and variant list:
+
+```bash
+curl -X POST http://localhost:8000/ab_tests -H 'Content-Type: application/json' \
+  -d '{"name": "Title Test", "variants": ["A", "B"]}'
+```
+
+Record user interactions with `/ab_tests/{variant_id}/impression` and
+`/ab_tests/{variant_id}/click`. Retrieve conversion metrics with
+`/ab_tests/{test_id}/metrics` or `/ab_tests/metrics` for all tests. The dashboard
+page at `/ab_tests` lets you create tests and view results.

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -33,6 +33,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
+          <Link href="/ab_tests" className="hover:underline">{t('nav.abTests')}</Link>
           <LanguageSwitcher />
           <Link
             href="/notifications"

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -1,50 +1,49 @@
 {
-  "nav": {
-    "home": "Home",
-    "generate": "Generate",
-    "categories": "Categories",
-    "designIdeas": "Design Ideas",
-    "suggestions": "Suggestions",
-    "search": "Search",
-    "analytics": "Analytics"
-  },
-  "index": {
-    "trending": "Trending Keywords",
-    "events": "This Month's Events"
-  },
-  "categories": {
-    "title": "Trending Categories"
-  },
-  "design": {
-    "title": "Design Ideas"
-  },
-  "generate": {
-    "title": "Generate Product Idea",
-    "placeholder": "Enter trend term",
-    "button": "Generate"
-  },
-  "suggestions": {
-    "title": "Product Suggestions",
-    "category": "Category",
-    "designTheme": "Design Theme",
-    "fetch": "Fetch"
-  },
-  "review": {
-    "title": "Image Review",
-    "noProducts": "No products to review.",
-    "rating": "Rating",
-    "unrated": "Unrated",
-    "stars_one": "{{count}} Star",
-    "stars_other": "{{count}} Stars",
-    "tags": "Tags",
-    "flag": "Flag as inappropriate"
-  },
-  "analytics": {
-    "title": "Keyword Analytics",
-    "revenue": "Revenue"
-  },
-  "notifications": {
-    "title": "Notifications",
-    "markRead": "Mark as read"
-  }
+    "nav": {
+        "home": "Home",
+        "generate": "Generate",
+        "categories": "Categories",
+        "designIdeas": "Design Ideas",
+        "suggestions": "Suggestions",
+        "search": "Search",
+        "analytics": "Analytics",
+        "abTests": "A/B Tests",
+        "notifications": "Notifications",
+    },
+    "index": {"trending": "Trending Keywords", "events": "This Month's Events"},
+    "categories": {"title": "Trending Categories"},
+    "design": {"title": "Design Ideas"},
+    "generate": {
+        "title": "Generate Product Idea",
+        "placeholder": "Enter trend term",
+        "button": "Generate",
+    },
+    "suggestions": {
+        "title": "Product Suggestions",
+        "category": "Category",
+        "designTheme": "Design Theme",
+        "fetch": "Fetch",
+    },
+    "review": {
+        "title": "Image Review",
+        "noProducts": "No products to review.",
+        "rating": "Rating",
+        "unrated": "Unrated",
+        "stars_one": "{{count}} Star",
+        "stars_other": "{{count}} Stars",
+        "tags": "Tags",
+        "flag": "Flag as inappropriate",
+    },
+    "analytics": {"title": "Keyword Analytics", "revenue": "Revenue"},
+    "notifications": {"title": "Notifications", "markRead": "Mark as read"},
+    "ab": {
+        "title": "A/B Tests",
+        "name": "Test Name",
+        "variants": "Variants (comma separated)",
+        "create": "Create",
+        "variant": "Variant",
+        "impressions": "Impressions",
+        "clicks": "Clicks",
+        "rate": "Conversion Rate",
+    },
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -1,50 +1,49 @@
 {
-  "nav": {
-    "home": "Inicio",
-    "generate": "Generar",
-    "categories": "Categorías",
-    "designIdeas": "Ideas de diseño",
-    "suggestions": "Sugerencias",
-    "search": "Buscar",
-    "analytics": "Analíticas"
-  },
-  "index": {
-    "trending": "Palabras clave en tendencia",
-    "events": "Eventos del mes"
-  },
-  "categories": {
-    "title": "Categorías en tendencia"
-  },
-  "design": {
-    "title": "Ideas de diseño"
-  },
-  "generate": {
-    "title": "Generar idea de producto",
-    "placeholder": "Introduce un término",
-    "button": "Generar"
-  },
-  "suggestions": {
-    "title": "Sugerencias de producto",
-    "category": "Categoría",
-    "designTheme": "Tema de diseño",
-    "fetch": "Buscar"
-  },
-  "review": {
-    "title": "Revisión de imágenes",
-    "noProducts": "No hay productos para revisar.",
-    "rating": "Calificación",
-    "unrated": "Sin calificar",
-    "stars_one": "{{count}} estrella",
-    "stars_other": "{{count}} estrellas",
-    "tags": "Etiquetas",
-    "flag": "Marcar como inapropiado"
-  },
-  "analytics": {
-    "title": "Analítica de palabras clave",
-    "revenue": "Ingresos"
-  },
-  "notifications": {
-    "title": "Notificaciones",
-    "markRead": "Marcar como leído"
-  }
+    "nav": {
+        "home": "Inicio",
+        "generate": "Generar",
+        "categories": "Categorías",
+        "designIdeas": "Ideas de diseño",
+        "suggestions": "Sugerencias",
+        "search": "Buscar",
+        "analytics": "Analíticas",
+        "abTests": "Pruebas A/B",
+        "notifications": "Notificaciones",
+    },
+    "index": {"trending": "Palabras clave en tendencia", "events": "Eventos del mes"},
+    "categories": {"title": "Categorías en tendencia"},
+    "design": {"title": "Ideas de diseño"},
+    "generate": {
+        "title": "Generar idea de producto",
+        "placeholder": "Introduce un término",
+        "button": "Generar",
+    },
+    "suggestions": {
+        "title": "Sugerencias de producto",
+        "category": "Categoría",
+        "designTheme": "Tema de diseño",
+        "fetch": "Buscar",
+    },
+    "review": {
+        "title": "Revisión de imágenes",
+        "noProducts": "No hay productos para revisar.",
+        "rating": "Calificación",
+        "unrated": "Sin calificar",
+        "stars_one": "{{count}} estrella",
+        "stars_other": "{{count}} estrellas",
+        "tags": "Etiquetas",
+        "flag": "Marcar como inapropiado",
+    },
+    "analytics": {"title": "Analítica de palabras clave", "revenue": "Ingresos"},
+    "notifications": {"title": "Notificaciones", "markRead": "Marcar como leído"},
+    "ab": {
+        "title": "Pruebas A/B",
+        "name": "Nombre de prueba",
+        "variants": "Variantes separadas por coma",
+        "create": "Crear",
+        "variant": "Variante",
+        "impressions": "Impresiones",
+        "clicks": "Clics",
+        "rate": "Tasa de conversión",
+    },
 }

--- a/client/pages/ab_tests.tsx
+++ b/client/pages/ab_tests.tsx
@@ -1,0 +1,101 @@
+import { GetServerSideProps } from 'next';
+import axios from 'axios';
+import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+export type ABMetric = {
+  id: number;
+  test_id: number;
+  name: string;
+  impressions: number;
+  clicks: number;
+  conversion_rate: number;
+};
+
+interface Props {
+  metrics: ABMetric[];
+}
+
+export default function ABTests({ metrics: initial }: Props) {
+  const { t } = useTranslation('common');
+  const [metrics, setMetrics] = useState<ABMetric[]>(initial);
+  const [name, setName] = useState('');
+  const [variants, setVariants] = useState('');
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parts = variants
+      .split(',')
+      .map(v => v.trim())
+      .filter(Boolean);
+    if (!name || !parts.length) return;
+    try {
+      const res = await axios.post(`${api}/ab_tests`, {
+        name,
+        variants: parts,
+      });
+      const metricsRes = await axios.get<ABMetric[]>(
+        `${api}/ab_tests/${res.data.id}/metrics`
+      );
+      setMetrics(metricsRes.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">{t('ab.title')}</h1>
+      <form onSubmit={submit} className="flex flex-col gap-2 max-w-md">
+        <input
+          className="border p-2"
+          placeholder={t('ab.name') as string}
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder={t('ab.variants') as string}
+          value={variants}
+          onChange={e => setVariants(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          {t('ab.create')}
+        </button>
+      </form>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2">{t('ab.variant')}</th>
+            <th className="border px-2">{t('ab.impressions')}</th>
+            <th className="border px-2">{t('ab.clicks')}</th>
+            <th className="border px-2">{t('ab.rate')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {metrics.map(m => (
+            <tr key={m.id}>
+              <td className="border px-2">{m.name}</td>
+              <td className="border px-2" data-testid={`imp-${m.id}`}>{m.impressions}</td>
+              <td className="border px-2">{m.clicks}</td>
+              <td className="border px-2">{(m.conversion_rate * 100).toFixed(1)}%</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  try {
+    const res = await axios.get<ABMetric[]>(`${api}/ab_tests/metrics`);
+    return { props: { metrics: res.data } };
+  } catch (err) {
+    console.error(err);
+    return { props: { metrics: [] } };
+  }
+};
+

--- a/services/ab_tests/api.py
+++ b/services/ab_tests/api.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .service import (
+    create_test,
+    get_metrics,
+    record_click,
+    record_impression,
+)
+
+
+app = FastAPI()
+
+
+class TestCreate(BaseModel):
+    name: str
+    variants: list[str]
+
+
+@app.post("/")
+async def create(payload: TestCreate):
+    return await create_test(payload.name, payload.variants)
+
+
+@app.get("/metrics")
+async def metrics_all():
+    return await get_metrics()
+
+
+@app.get("/{test_id}/metrics")
+async def metrics(test_id: int):
+    return await get_metrics(test_id)
+
+
+@app.post("/{variant_id}/click")
+async def click(variant_id: int):
+    data = await record_click(variant_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Variant not found")
+    return data
+
+
+@app.post("/{variant_id}/impression")
+async def impression(variant_id: int):
+    data = await record_impression(variant_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Variant not found")
+    return data

--- a/services/ab_tests/service.py
+++ b/services/ab_tests/service.py
@@ -1,0 +1,73 @@
+from typing import List, Optional
+
+from sqlmodel import select
+
+from ..common.database import get_session
+from ..models import ABTest, ABVariant
+
+
+def _variant_dict(variant: ABVariant) -> dict:
+    rate = (variant.clicks / variant.impressions) if variant.impressions else 0
+    return {
+        "id": variant.id,
+        "test_id": variant.test_id,
+        "name": variant.name,
+        "impressions": variant.impressions,
+        "clicks": variant.clicks,
+        "conversion_rate": rate,
+    }
+
+
+async def create_test(name: str, variants: List[str]) -> dict:
+    """Create a new A/B test with variants."""
+    async with get_session() as session:
+        test = ABTest(name=name)
+        session.add(test)
+        await session.commit()
+        await session.refresh(test)
+        test_id = test.id
+        variant_dicts = []
+        for v in variants:
+            variant = ABVariant(test_id=test_id, name=v)
+            session.add(variant)
+            await session.commit()
+            await session.refresh(variant)
+            variant_dicts.append(_variant_dict(variant))
+        return {"id": test_id, "name": test.name, "variants": variant_dicts}
+
+
+async def get_metrics(test_id: int | None = None) -> List[dict]:
+    """Return metrics for all variants or those belonging to a specific test."""
+    async with get_session() as session:
+        stmt = select(ABVariant)
+        if test_id is not None:
+            stmt = stmt.where(ABVariant.test_id == test_id)
+        result = await session.exec(stmt)
+        variants = result.all()
+        return [_variant_dict(v) for v in variants]
+
+
+async def record_click(variant_id: int) -> Optional[dict]:
+    """Increment click count for a variant."""
+    async with get_session() as session:
+        variant = await session.get(ABVariant, variant_id)
+        if not variant:
+            return None
+        variant.clicks += 1
+        session.add(variant)
+        await session.commit()
+        await session.refresh(variant)
+        return _variant_dict(variant)
+
+
+async def record_impression(variant_id: int) -> Optional[dict]:
+    """Increment impression count for a variant."""
+    async with get_session() as session:
+        variant = await session.get(ABVariant, variant_id)
+        if not variant:
+            return None
+        variant.impressions += 1
+        session.add(variant)
+        await session.commit()
+        await session.refresh(variant)
+        return _variant_dict(variant)

--- a/services/common/database.py
+++ b/services/common/database.py
@@ -21,5 +21,5 @@ async def init_db() -> None:
 
 @asynccontextmanager
 async def get_session() -> AsyncSession:
-    async with AsyncSession(engine) as session:
+    async with AsyncSession(engine, expire_on_commit=False) as session:
         yield session

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -12,12 +12,14 @@ from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
 from ..notifications.api import app as notifications_app
 from ..search.api import app as search_app
+from ..ab_tests.api import app as ab_app
 from ..trend_scraper.events import EVENTS
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
 app.mount("/api/search", search_app)
+app.mount("/ab_tests", ab_app)
 
 
 @app.post("/generate")

--- a/services/models.py
+++ b/services/models.py
@@ -49,3 +49,21 @@ class Notification(SQLModel, table=True):
     message: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
     read: bool = False
+
+
+class ABTest(SQLModel, table=True):
+    """Top level A/B test container."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ABVariant(SQLModel, table=True):
+    """Variant belonging to an A/B test."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    test_id: int
+    name: str
+    impressions: int = 0
+    clicks: int = 0

--- a/tests/e2e/ab_tests.spec.ts
+++ b/tests/e2e/ab_tests.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('ab tests page creates experiment', async ({ page }) => {
+  await page.route('**/ab_tests', route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 1, name: 'Test', variants: [{ id: 10, name: 'A' }] }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 10, test_id: 1, name: 'A', impressions: 1, clicks: 1, conversion_rate: 1 }]),
+      });
+    }
+  });
+
+  await page.goto('/ab_tests');
+  await page.getByPlaceholder('Test Name').fill('MyTest');
+  await page.getByPlaceholder('Variants (comma separated)').fill('A');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByTestId('imp-10')).toBeVisible();
+});

--- a/tests/test_ab_tests_api.py
+++ b/tests/test_ab_tests_api.py
@@ -1,0 +1,24 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.ab_tests.api import app as ab_app
+from services.common.database import init_db
+
+
+@pytest.mark.asyncio
+async def test_ab_tests_api():
+    await init_db()
+    transport = ASGITransport(app=ab_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/", json={"name": "Test", "variants": ["A"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        vid = data["variants"][0]["id"]
+        resp = await client.post(f"/{vid}/impression")
+        assert resp.status_code == 200
+        resp = await client.post(f"/{vid}/click")
+        assert resp.status_code == 200
+        resp = await client.get(f"/{data['id']}/metrics")
+        assert resp.status_code == 200
+        metrics = resp.json()
+        assert len(metrics) == 1
+        assert metrics[0]["clicks"] == 1

--- a/tests/test_ab_tests_service.py
+++ b/tests/test_ab_tests_service.py
@@ -1,0 +1,24 @@
+import pytest
+from services.ab_tests.service import (
+    create_test,
+    get_metrics,
+    record_click,
+    record_impression,
+)
+from services.common.database import init_db
+
+
+@pytest.mark.asyncio
+async def test_ab_service_flow():
+    await init_db()
+    test = await create_test("Example", ["A", "B"])
+    assert test["name"] == "Example"
+    assert len(test["variants"]) == 2
+    vid = test["variants"][0]["id"]
+    await record_impression(vid)
+    await record_click(vid)
+    metrics = await get_metrics(test["id"])
+    var = next(v for v in metrics if v["id"] == vid)
+    assert var["impressions"] == 1
+    assert var["clicks"] == 1
+    assert var["conversion_rate"] == 1.0


### PR DESCRIPTION
## Summary
- add ABTest and ABVariant models
- implement AB testing service and API
- mount `/ab_tests` in gateway
- add dashboard page for A/B testing
- update translations and README instructions
- include tests for service, API and page

## Testing
- `flake8 services/ab_tests/api.py services/ab_tests/service.py tests/test_ab_tests_api.py tests/test_ab_tests_service.py client/components/Layout.tsx`
- `pytest -q tests/test_ab_tests_service.py tests/test_ab_tests_api.py`
- `npx playwright test tests/e2e/ab_tests.spec.ts` *(fails: needs playwright install)*


------
https://chatgpt.com/codex/tasks/task_e_688611cb524c832b80e14340f46b6033