### PR TITLE
Implement listing composer enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ Filter products using the `/api/search` endpoint. You can pass `q`, `category`,
 ```bash
 curl "http://localhost:8000/api/search?q=dog&category=apparel&tag=funny&rating_min=3"
 ```
+
+## Listing Composer
+
+Create Etsy listings with optimised metadata. Navigate to `/listings` in the dashboard and enter a title and description. Character counters show how many characters remain for each field. Click **Suggest Tags** to fetch recommended tags from the backend via the `/suggest-tags` endpoint. Select up to 13 tags before publishing your listing.

--- a/client/__tests__/ListingComposer.test.tsx
+++ b/client/__tests__/ListingComposer.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import ListingComposer from '../components/ListingComposer';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key.replace('listings.', '') }),
+}));
+
+jest.mock('../services/listings', () => ({
+  fetchTagSuggestions: jest.fn(() => Promise.resolve(['one', 'two'])),
+}));
+
+const onPublish = jest.fn();
+
+test('shows character counts and adds tags', async () => {
+  render(<ListingComposer onPublish={onPublish} />);
+  const titleInput = screen.getAllByRole('textbox')[0];
+  fireEvent.change(titleInput, { target: { value: 'Hello' } });
+  expect(screen.getByText(/5\/140/)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByText('suggest'));
+  const tagButton = await screen.findByRole('button', { name: 'one' });
+  fireEvent.click(tagButton);
+  expect(screen.getAllByText('one').length).toBeGreaterThan(0);
+});

--- a/client/__tests__/listingsService.test.ts
+++ b/client/__tests__/listingsService.test.ts
@@ -1,0 +1,14 @@
+import { fetchTagSuggestions } from '../services/listings';
+import axios from 'axios';
+
+jest.mock('axios');
+const mocked = axios as jest.Mocked<typeof axios>;
+
+describe('fetchTagSuggestions', () => {
+  it('fetches tags from API', async () => {
+    mocked.post.mockResolvedValue({ data: ['tag1', 'tag2'] });
+    const tags = await fetchTagSuggestions('t', 'd');
+    expect(tags).toEqual(['tag1', 'tag2']);
+    expect(mocked.post).toHaveBeenCalled();
+  });
+});

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -32,6 +32,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
+          <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <LanguageSwitcher />
           <Link

--- a/client/components/ListingComposer.tsx
+++ b/client/components/ListingComposer.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { fetchTagSuggestions } from '../services/listings';
+
+interface Props {
+  onPublish?: (data: any) => void;
+}
+
+export default function ListingComposer({ onPublish }: Props) {
+  const { t } = useTranslation('common');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [suggested, setSuggested] = useState<string[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const getSuggestions = async () => {
+    try {
+      const res = await fetchTagSuggestions(title, description);
+      setSuggested(res);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const toggleTag = (tag: string) => {
+    if (tags.includes(tag)) {
+      setTags(tags.filter(t => t !== tag));
+    } else if (tags.length < 13) {
+      setTags([...tags, tag]);
+    }
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onPublish?.({ title, description, tags });
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          {t('listings.title')} ({title.length}/140)
+        </label>
+        <input
+          className="border p-2 w-full"
+          maxLength={140}
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          {t('listings.description')} ({description.length}/1000)
+        </label>
+        <textarea
+          className="border p-2 w-full"
+          maxLength={1000}
+          rows={4}
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          {t('listings.tags')} ({tags.length}/13)
+        </label>
+        <div className="flex flex-wrap gap-2 mb-2">
+          {tags.map(tg => (
+            <span
+              key={tg}
+              className="bg-gray-200 px-2 py-1 rounded cursor-pointer"
+              onClick={() => toggleTag(tg)}
+            >
+              {tg}
+            </span>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={getSuggestions}
+          className="text-sm text-blue-500"
+        >
+          {t('listings.suggest')}
+        </button>
+        <div className="flex flex-wrap gap-2 mt-2">
+          {suggested.map(tag => (
+            <button
+              type="button"
+              key={tag}
+              onClick={() => toggleTag(tag)}
+              className={`border px-2 py-1 rounded ${tags.includes(tag) ? 'bg-blue-600 text-white' : ''}`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+        {t('listings.publish')}
+      </button>
+    </form>
+  );
+}

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: 'ts-jest/presets/js-with-ts',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: { jsx: 'react' } }],
+  },
+};

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -6,7 +6,9 @@
     "designIdeas": "Design Ideas",
     "suggestions": "Suggestions",
     "search": "Search",
-    "analytics": "Analytics"
+    "analytics": "Analytics",
+    "listings": "Listings",
+    "notifications": "Notifications"
   },
   "index": {
     "trending": "Trending Keywords",
@@ -38,6 +40,13 @@
     "stars_other": "{{count}} Stars",
     "tags": "Tags",
     "flag": "Flag as inappropriate"
+  },
+  "listings": {
+    "title": "Listing Composer",
+    "description": "Description",
+    "tags": "Tags",
+    "suggest": "Suggest Tags",
+    "publish": "Publish"
   },
   "analytics": {
     "title": "Keyword Analytics",

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -6,7 +6,9 @@
     "designIdeas": "Ideas de diseño",
     "suggestions": "Sugerencias",
     "search": "Buscar",
-    "analytics": "Analíticas"
+    "analytics": "Analíticas",
+    "listings": "Publicaciones",
+    "notifications": "Notificaciones"
   },
   "index": {
     "trending": "Palabras clave en tendencia",
@@ -38,6 +40,13 @@
     "stars_other": "{{count}} estrellas",
     "tags": "Etiquetas",
     "flag": "Marcar como inapropiado"
+  },
+  "listings": {
+    "title": "Compositor de publicaciones",
+    "description": "Descripción",
+    "tags": "Etiquetas",
+    "suggest": "Sugerir etiquetas",
+    "publish": "Publicar"
   },
   "analytics": {
     "title": "Analítica de palabras clave",

--- a/client/pages/listings.tsx
+++ b/client/pages/listings.tsx
@@ -1,0 +1,12 @@
+import ListingComposer from '../components/ListingComposer';
+import { useTranslation } from 'next-i18next';
+
+export default function Listings() {
+  const { t } = useTranslation('common');
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">{t('listings.title')}</h1>
+      <ListingComposer />
+    </div>
+  );
+}

--- a/client/services/listings.ts
+++ b/client/services/listings.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export async function fetchTagSuggestions(title: string, description: string): Promise<string[]> {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const res = await axios.post<string[]>(`${api}/suggest-tags`, { title, description });
+  return res.data;
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,7 +18,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "types": [
-      "node"
+      "node",
+      "jest"
     ]
   },
   "include": [

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -6,7 +6,7 @@ from ..trend_scraper.service import (
     get_design_ideas,
     get_product_suggestions,
 )
-from ..ideation.service import generate_ideas
+from ..ideation.service import generate_ideas, suggest_tags
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
@@ -47,3 +47,10 @@ async def design_ideas(category: str | None = None):
 @app.get("/product-suggestions")
 async def product_suggestions(category: str | None = None, design: str | None = None):
     return get_product_suggestions(category, design)
+
+
+@app.post("/suggest-tags")
+async def suggest_tags_endpoint(data: dict):
+    title = data.get("title", "")
+    description = data.get("description", "")
+    return suggest_tags(title, description)

--- a/services/ideation/api.py
+++ b/services/ideation/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import generate_ideas
+from .service import generate_ideas, suggest_tags
 
 app = FastAPI()
 
@@ -9,6 +9,16 @@ class TrendList(BaseModel):
     trends: list[str]
 
 
+class ListingData(BaseModel):
+    title: str
+    description: str
+
+
 @app.post("/ideas")
 async def ideas(data: TrendList):
     return await generate_ideas(data.trends)
+
+
+@app.post("/suggest-tags")
+async def tags(data: ListingData):
+    return suggest_tags(data.title, data.description)

--- a/services/ideation/service.py
+++ b/services/ideation/service.py
@@ -64,3 +64,31 @@ async def generate_ideas(trends: List[TrendInput]) -> List[Dict]:
                 {"description": idea.description, "term": term, "category": cat}
             )
     return ideas
+
+
+def suggest_tags(title: str, description: str) -> List[str]:
+    """Return a list of up to 13 tag suggestions based on title and description."""
+    text = f"{title} {description}"
+    words = [w.strip(".,!?:;\"'()[]{}").lower() for w in text.split()]
+    stop = {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "in",
+        "with",
+        "to",
+        "for",
+        "on",
+        "at",
+        "by",
+    }
+    tags: List[str] = []
+    for w in words:
+        if w and w not in stop and w not in tags:
+            tags.append(w)
+        if len(tags) >= 13:
+            break
+    return tags

--- a/tests/test_tag_suggestions.py
+++ b/tests/test_tag_suggestions.py
@@ -1,0 +1,27 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from services.gateway.api import app as gateway_app
+from services.ideation.service import suggest_tags
+
+
+@pytest.mark.asyncio
+async def test_suggest_tags_function():
+    tags = suggest_tags("Funny Dog Shirt", "This is a hilarious dog t-shirt")
+    assert "funny" in tags
+    assert "dog" in tags
+    assert len(tags) <= 13
+
+
+@pytest.mark.asyncio
+async def test_suggest_tags_endpoint():
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/suggest-tags",
+            json={"title": "Cat Mug", "description": "Cute cat coffee mug"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert "cat" in data


### PR DESCRIPTION
## Summary
- add listing composer component and page
- fetch tag suggestions from `/suggest-tags` endpoint
- expose new `/suggest-tags` service in ideation and gateway
- link listings page in layout navigation
- update i18n files for new strings
- document listing composer usage
- add unit tests for listing composer and tag service
- add backend tests for tag suggestion endpoint

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68861175b5c4832bb6bfa1b97d51a50f