### PR TITLE
feat: add analytics service and dashboard

### DIFF
--- a/client/__tests__/AnalyticsPage.test.tsx
+++ b/client/__tests__/AnalyticsPage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import axios from 'axios';
+import Analytics, { SummaryRecord } from '../pages/analytics';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('axios');
+
+jest.mock('next/dynamic', () => () => (props: any) => <div data-testid="chart" {...props} />);
+
+jest.mock('react-chartjs-2', () => ({
+  Bar: ({}) => <div data-testid="chart" />,
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const initialData: SummaryRecord[] = [{ path: '/home', count: 1 }];
+
+it('renders analytics chart and changes filter', async () => {
+  render(<Analytics initialData={initialData} />);
+  expect(screen.getByTestId('chart')).toBeInTheDocument();
+  const select = screen.getByLabelText('analytics.filter');
+  mockedAxios.get.mockResolvedValueOnce({ data: [{ path: '/prod', count: 2 }] });
+  fireEvent.change(select, { target: { value: 'click' } });
+  await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledTimes(1));
+});

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -49,10 +49,12 @@
     "suggest": "Suggest Tags",
     "publish": "Publish"
   },
-  "analytics": {
-    "title": "Keyword Analytics",
-    "revenue": "Revenue"
-  },
+    "analytics": {
+      "title": "Keyword Analytics",
+      "revenue": "Revenue",
+      "filter": "Event Type",
+      "events": "Events"
+    },
   "notifications": {
     "title": "Notifications",
     "markRead": "Mark as read"

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -48,10 +48,12 @@
     "suggest": "Sugerir etiquetas",
     "publish": "Publicar"
   },
-  "analytics": {
-    "title": "Analítica de palabras clave",
-    "revenue": "Ingresos"
-  },
+    "analytics": {
+      "title": "Analítica de palabras clave",
+      "revenue": "Ingresos",
+      "filter": "Tipo de evento",
+      "events": "Eventos"
+    },
   "notifications": {
     "title": "Notificaciones",
     "markRead": "Marcar como leído"

--- a/client/services/analytics.ts
+++ b/client/services/analytics.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { SummaryRecord } from '../pages/analytics';
+
+const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+export async function fetchSummary(eventType: string): Promise<SummaryRecord[]> {
+  const res = await axios.get<SummaryRecord[]>(`${api}/analytics/summary`, {
+    params: { event_type: eventType },
+  });
+  return res.data;
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -1,0 +1,25 @@
+# Analytics Service
+
+## Architecture
+The analytics module records user interactions and exposes aggregated metrics for the dashboard.
+
+### Components
+- **Model**: `AnalyticsEvent` in `services/models.py` stores `event_type`, `path`, optional `user_id` and `metadata`.
+- **API** (`services/analytics/api.py`):
+  - `POST /analytics/events` – record an event.
+  - `GET /analytics/events` – list events by type.
+  - `GET /analytics/summary` – aggregate counts per path.
+- **Middleware**: `AnalyticsMiddleware` attaches to FastAPI apps and logs `page_view` events asynchronously to keep p95 latency under 300 ms.
+- **Stripe Usage**: conversion events trigger an async usage report to Stripe for billing (skipped when `STRIPE_API_KEY` is absent).
+
+### Data Flow
+1. Requests hit any FastAPI service using `AnalyticsMiddleware`.
+2. Middleware schedules a background task to persist the event.
+3. Stored events are aggregated via `/analytics/summary` and rendered in the dashboard charts.
+
+## Usage
+Mount the middleware on additional services as needed:
+```python
+from services.analytics.middleware import AnalyticsMiddleware
+app.add_middleware(AnalyticsMiddleware)
+```

--- a/services/analytics/api.py
+++ b/services/analytics/api.py
@@ -1,16 +1,42 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import get_top_keywords
+from datetime import datetime
+from typing import Dict, Any
+from .service import log_event, list_events, get_summary
+from .middleware import AnalyticsMiddleware
 
 app = FastAPI()
+app.add_middleware(AnalyticsMiddleware)
 
 
-class KeywordClicks(BaseModel):
-    keyword: str
-    clicks: int
-    revenue: float
+class EventIn(BaseModel):
+    event_type: str
+    path: str
+    user_id: int | None = None
+    meta: Dict[str, Any] | None = None
 
 
-@app.get("/analytics", response_model=list[KeywordClicks])
-async def analytics():
-    return get_top_keywords()
+class EventOut(EventIn):
+    id: int
+    created_at: datetime
+
+
+class SummaryOut(BaseModel):
+    path: str
+    count: int
+
+
+@app.post("/analytics/events", response_model=EventOut, status_code=201)
+async def create_event(event: EventIn):
+    return await log_event(**event.model_dump())
+
+
+@app.get("/analytics/events", response_model=list[EventOut])
+async def get_events(event_type: str | None = None):
+    events = await list_events(event_type)
+    return [EventOut(**e.model_dump()) for e in events]
+
+
+@app.get("/analytics/summary", response_model=list[SummaryOut])
+async def summary(event_type: str | None = None):
+    return await get_summary(event_type)

--- a/services/analytics/middleware.py
+++ b/services/analytics/middleware.py
@@ -1,0 +1,12 @@
+import asyncio
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from .service import log_event
+
+
+class AnalyticsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response: Response = await call_next(request)
+        asyncio.create_task(log_event("page_view", request.url.path))
+        return response

--- a/services/analytics/repository.py
+++ b/services/analytics/repository.py
@@ -1,0 +1,32 @@
+from sqlmodel import select
+from sqlalchemy.sql import func
+from sqlmodel.ext.asyncio.session import AsyncSession
+from ..models import AnalyticsEvent
+
+
+async def create_event(session: AsyncSession, event: AnalyticsEvent) -> AnalyticsEvent:
+    session.add(event)
+    await session.commit()
+    await session.refresh(event)
+    return event
+
+
+def _event_query(event_type: str | None = None):
+    stmt = select(AnalyticsEvent)
+    if event_type:
+        stmt = stmt.where(AnalyticsEvent.event_type == event_type)
+    return stmt
+
+
+async def fetch_events(session: AsyncSession, event_type: str | None = None) -> list[AnalyticsEvent]:
+    result = await session.exec(_event_query(event_type))
+    return result.all()
+
+
+async def aggregate_events(session: AsyncSession, event_type: str | None = None):
+    stmt = select(AnalyticsEvent.path, func.count(AnalyticsEvent.id).label("count"))
+    if event_type:
+        stmt = stmt.where(AnalyticsEvent.event_type == event_type)
+    stmt = stmt.group_by(AnalyticsEvent.path)
+    result = await session.exec(stmt)
+    return result.all()

--- a/services/analytics/service.py
+++ b/services/analytics/service.py
@@ -1,17 +1,56 @@
-MOCK_ANALYTICS = [
-    {"keyword": "dog shirts", "clicks": 120, "revenue": 1250.5},
-    {"keyword": "cat mugs", "clicks": 95, "revenue": 980.0},
-    {"keyword": "sustainability", "clicks": 87, "revenue": 910.75},
-    {"keyword": "yoga pants", "clicks": 76, "revenue": 830.25},
-    {"keyword": "retro vinyl", "clicks": 70, "revenue": 799.0},
-    {"keyword": "wedding season", "clicks": 65, "revenue": 760.0},
-    {"keyword": "photo blankets", "clicks": 58, "revenue": 620.4},
-    {"keyword": "custom mugs", "clicks": 54, "revenue": 540.0},
-    {"keyword": "gaming tees", "clicks": 50, "revenue": 512.3},
-    {"keyword": "motivational posters", "clicks": 45, "revenue": 450.0},
-]
+import asyncio
+import os
+import httpx
+from typing import Dict, Any
+from .repository import create_event, fetch_events, aggregate_events
+from ..common.database import get_session
+from ..models import AnalyticsEvent
+
+STRIPE_API_KEY = os.getenv("STRIPE_API_KEY")
 
 
-def get_top_keywords():
-    """Return mocked analytics data."""
-    return MOCK_ANALYTICS
+async def _report_conversion_to_stripe(quantity: int = 1) -> None:
+    if not STRIPE_API_KEY:
+        return
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            await client.post(
+                "https://api.stripe.com/v1/usage_records",
+                auth=(STRIPE_API_KEY, ""),
+                data={"quantity": quantity},
+            )
+    except httpx.HTTPError as exc:
+        # log but do not raise to keep latency low
+        print(f"Stripe usage report failed: {exc}")
+
+
+async def log_event(
+    event_type: str,
+    path: str,
+    user_id: int | None = None,
+    meta: Dict[str, Any] | None = None,
+) -> AnalyticsEvent:
+    async with get_session() as session:
+        event = AnalyticsEvent(
+            event_type=event_type,
+            path=path,
+            user_id=user_id,
+            meta=meta,
+        )
+        created = await create_event(session, event)
+    if event_type == "conversion":
+        asyncio.create_task(_report_conversion_to_stripe())
+    return created
+
+
+async def list_events(event_type: str | None = None):
+    async with get_session() as session:
+        return await fetch_events(session, event_type)
+
+
+async def get_summary(event_type: str | None = None):
+    async with get_session() as session:
+        rows = await aggregate_events(session, event_type)
+    return [
+        {"path": path, "count": count} for path, count in rows
+    ]

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -14,12 +14,14 @@ from ..notifications.api import app as notifications_app
 from ..search.api import app as search_app
 from ..ab_tests.api import app as ab_app
 from ..trend_scraper.events import EVENTS
+from ..analytics.middleware import AnalyticsMiddleware
 
 app = FastAPI()
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
 app.mount("/api/search", search_app)
 app.mount("/ab_tests", ab_app)
+app.add_middleware(AnalyticsMiddleware)
 
 
 @app.post("/generate")

--- a/services/models.py
+++ b/services/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Dict, Any
 from sqlmodel import SQLModel, Field
 from sqlalchemy import Column, JSON
 from datetime import datetime
@@ -67,3 +67,14 @@ class ABVariant(SQLModel, table=True):
     name: str
     impressions: int = 0
     clicks: int = 0
+
+
+class AnalyticsEvent(SQLModel, table=True):
+    """Stored analytics event for dashboards."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    event_type: str
+    path: str
+    user_id: Optional[int] = None
+    meta: Dict[str, Any] | None = Field(default=None, sa_column=Column("metadata", JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/status.md
+++ b/status.md
@@ -11,7 +11,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 
 1. **Real Integrations** – Implement Printify and Etsy clients, replacing stubs in `services/integration/service.py`. Use environment variables for API keys and handle retries. Stripe billing integration also needs to be built for subscription plans.
 2. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
-3. **Analytics Enhancements** – Replace mocked analytics with real metrics collected from the database and user interactions.
+3. **Analytics Enhancements** – DONE. Real metrics are now collected from the database and exposed via a dashboard.
 4. **Listing Composer Enhancements** – Finalise the character-count and tag-suggestion features; ensure they are merged and tested.
 5. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
 6. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,16 +1,35 @@
 import pytest
 from httpx import AsyncClient, ASGITransport
 from services.analytics.api import app as analytics_app
+from services.analytics.service import list_events
+from services.common.database import init_db
 
 
 @pytest.mark.asyncio
-async def test_analytics_endpoint():
+async def test_event_logging_and_summary():
+    await init_db()
     transport = ASGITransport(app=analytics_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/analytics")
+        resp = await client.post(
+            "/analytics/events",
+            json={"event_type": "click", "path": "/home"},
+        )
+        assert resp.status_code == 201
+        created = resp.json()
+        assert created["event_type"] == "click"
+
+        resp = await client.get("/analytics/summary", params={"event_type": "click"})
         assert resp.status_code == 200
-        data = resp.json()
-        assert isinstance(data, list)
-        assert len(data) == 10
-        first = data[0]
-        assert "keyword" in first and "clicks" in first
+        summary = resp.json()
+        assert summary[0]["path"] == "/home"
+        assert summary[0]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_middleware_logs_page_view():
+    await init_db()
+    transport = ASGITransport(app=analytics_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/analytics/summary")
+    events = await list_events("page_view")
+    assert any(e.path == "/analytics/summary" for e in events)


### PR DESCRIPTION
## Summary
- implement AnalyticsEvent model, API endpoints, repository, and middleware
- integrate analytics into gateway and expose summary for dashboard
- add Next.js analytics page with filterable chart and tests
- document analytics architecture and update project status

## Testing
- `pytest tests/test_analytics.py tests/test_gateway.py`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd9994224832bbecdffdf4bdb15d9