### PR TITLE
feat: add social media generator

### DIFF
--- a/client/__tests__/SocialMediaGenerator.test.tsx
+++ b/client/__tests__/SocialMediaGenerator.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import SocialMediaGenerator from '../components/SocialMediaGenerator';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key.split('.').pop() })
+}));
+
+jest.mock('../services/socialGenerator', () => ({
+  generateSocialPost: jest.fn(() => Promise.resolve({
+    caption: 'mock caption',
+    image_url: 'http://example.com/image.png'
+  }))
+}));
+
+test('generates caption and shows image', async () => {
+  render(<SocialMediaGenerator />);
+  fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'hi' } });
+  fireEvent.click(screen.getByText('button'));
+  expect(await screen.findByText('mock caption')).toBeInTheDocument();
+  const img = screen.getByRole('img') as HTMLImageElement;
+  expect(img.getAttribute('src')).toContain('image.png');
+});

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -34,6 +34,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
+          <Link href="/social-generator" className="hover:underline">{t('nav.socialGenerator')}</Link>
           <Link href="/ab_tests" className="hover:underline">{t('nav.abTests')}</Link>
           <LanguageSwitcher />
           <Link

--- a/client/components/SocialMediaGenerator.tsx
+++ b/client/components/SocialMediaGenerator.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import Image from 'next/image';
+import { generateSocialPost, SocialPost } from '../services/socialGenerator';
+
+export default function SocialMediaGenerator() {
+  const { t } = useTranslation('common');
+  const [prompt, setPrompt] = useState('');
+  const [result, setResult] = useState<SocialPost | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+    try {
+      const data = await generateSocialPost(prompt);
+      setResult(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">{t('social.title')}</h1>
+      <form onSubmit={submit} className="flex gap-2" aria-label={t('social.title')}>
+        <label htmlFor="prompt" className="sr-only">
+          {t('social.prompt')}
+        </label>
+        <input
+          id="prompt"
+          name="prompt"
+          type="text"
+          className="border p-2 flex-grow"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder={t('social.prompt')}
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-2"
+        >
+          {loading ? '...' : t('social.button')}
+        </button>
+      </form>
+      {result && (
+        <div className="space-y-4">
+          <p>{result.caption}</p>
+          <Image
+            src={result.image_url}
+            alt={result.caption}
+            width={256}
+            height={256}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -1,5 +1,4 @@
 {
-
   "nav": {
     "home": "Home",
     "generate": "Generate",
@@ -9,18 +8,13 @@
     "search": "Search",
     "analytics": "Analytics",
     "listings": "Listings",
-    "notifications": "Notifications"
+    "abTests": "A/B Tests",
+    "notifications": "Notifications",
+    "socialGenerator": "Social Generator"
   },
-  "index": {
-    "trending": "Trending Keywords",
-    "events": "This Month's Events"
-  },
-  "categories": {
-    "title": "Trending Categories"
-  },
-  "design": {
-    "title": "Design Ideas"
-  },
+  "index": { "trending": "Trending Keywords", "events": "This Month's Events" },
+  "categories": { "title": "Trending Categories" },
+  "design": { "title": "Design Ideas" },
   "generate": {
     "title": "Generate Product Idea",
     "placeholder": "Enter trend term",
@@ -49,60 +43,21 @@
     "suggest": "Suggest Tags",
     "publish": "Publish"
   },
-  "analytics": {
-    "title": "Keyword Analytics",
-    "revenue": "Revenue"
+  "analytics": { "title": "Keyword Analytics", "revenue": "Revenue" },
+  "notifications": { "title": "Notifications", "markRead": "Mark as read" },
+  "ab": {
+    "title": "A/B Tests",
+    "name": "Test Name",
+    "variants": "Variants (comma separated)",
+    "create": "Create",
+    "variant": "Variant",
+    "impressions": "Impressions",
+    "clicks": "Clicks",
+    "rate": "Conversion Rate"
   },
-  "notifications": {
-    "title": "Notifications",
-    "markRead": "Mark as read"
+  "social": {
+    "title": "Social Media Generator",
+    "prompt": "Enter caption idea",
+    "button": "Generate"
   }
-=======
-    "nav": {
-        "home": "Home",
-        "generate": "Generate",
-        "categories": "Categories",
-        "designIdeas": "Design Ideas",
-        "suggestions": "Suggestions",
-        "search": "Search",
-        "analytics": "Analytics",
-        "abTests": "A/B Tests",
-        "notifications": "Notifications",
-    },
-    "index": {"trending": "Trending Keywords", "events": "This Month's Events"},
-    "categories": {"title": "Trending Categories"},
-    "design": {"title": "Design Ideas"},
-    "generate": {
-        "title": "Generate Product Idea",
-        "placeholder": "Enter trend term",
-        "button": "Generate",
-    },
-    "suggestions": {
-        "title": "Product Suggestions",
-        "category": "Category",
-        "designTheme": "Design Theme",
-        "fetch": "Fetch",
-    },
-    "review": {
-        "title": "Image Review",
-        "noProducts": "No products to review.",
-        "rating": "Rating",
-        "unrated": "Unrated",
-        "stars_one": "{{count}} Star",
-        "stars_other": "{{count}} Stars",
-        "tags": "Tags",
-        "flag": "Flag as inappropriate",
-    },
-    "analytics": {"title": "Keyword Analytics", "revenue": "Revenue"},
-    "notifications": {"title": "Notifications", "markRead": "Mark as read"},
-    "ab": {
-        "title": "A/B Tests",
-        "name": "Test Name",
-        "variants": "Variants (comma separated)",
-        "create": "Create",
-        "variant": "Variant",
-        "impressions": "Impressions",
-        "clicks": "Clicks",
-        "rate": "Conversion Rate",
-    },
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -8,18 +8,13 @@
     "search": "Buscar",
     "analytics": "Analíticas",
     "listings": "Publicaciones",
-    "notifications": "Notificaciones"
+    "abTests": "Pruebas A/B",
+    "notifications": "Notificaciones",
+    "socialGenerator": "Generador Social"
   },
-  "index": {
-    "trending": "Palabras clave en tendencia",
-    "events": "Eventos del mes"
-  },
-  "categories": {
-    "title": "Categorías en tendencia"
-  },
-  "design": {
-    "title": "Ideas de diseño"
-  },
+  "index": { "trending": "Palabras clave en tendencia", "events": "Eventos del mes" },
+  "categories": { "title": "Categorías en tendencia" },
+  "design": { "title": "Ideas de diseño" },
   "generate": {
     "title": "Generar idea de producto",
     "placeholder": "Introduce un término",
@@ -48,60 +43,21 @@
     "suggest": "Sugerir etiquetas",
     "publish": "Publicar"
   },
-  "analytics": {
-    "title": "Analítica de palabras clave",
-    "revenue": "Ingresos"
+  "analytics": { "title": "Analítica de palabras clave", "revenue": "Ingresos" },
+  "notifications": { "title": "Notificaciones", "markRead": "Marcar como leído" },
+  "ab": {
+    "title": "Pruebas A/B",
+    "name": "Nombre de prueba",
+    "variants": "Variantes separadas por coma",
+    "create": "Crear",
+    "variant": "Variante",
+    "impressions": "Impresiones",
+    "clicks": "Clics",
+    "rate": "Tasa de conversión"
   },
-  "notifications": {
-    "title": "Notificaciones",
-    "markRead": "Marcar como leído"
+  "social": {
+    "title": "Generador de Redes Sociales",
+    "prompt": "Introduce una idea de caption",
+    "button": "Generar"
   }
-=======
-    "nav": {
-        "home": "Inicio",
-        "generate": "Generar",
-        "categories": "Categorías",
-        "designIdeas": "Ideas de diseño",
-        "suggestions": "Sugerencias",
-        "search": "Buscar",
-        "analytics": "Analíticas",
-        "abTests": "Pruebas A/B",
-        "notifications": "Notificaciones",
-    },
-    "index": {"trending": "Palabras clave en tendencia", "events": "Eventos del mes"},
-    "categories": {"title": "Categorías en tendencia"},
-    "design": {"title": "Ideas de diseño"},
-    "generate": {
-        "title": "Generar idea de producto",
-        "placeholder": "Introduce un término",
-        "button": "Generar",
-    },
-    "suggestions": {
-        "title": "Sugerencias de producto",
-        "category": "Categoría",
-        "designTheme": "Tema de diseño",
-        "fetch": "Buscar",
-    },
-    "review": {
-        "title": "Revisión de imágenes",
-        "noProducts": "No hay productos para revisar.",
-        "rating": "Calificación",
-        "unrated": "Sin calificar",
-        "stars_one": "{{count}} estrella",
-        "stars_other": "{{count}} estrellas",
-        "tags": "Etiquetas",
-        "flag": "Marcar como inapropiado",
-    },
-    "analytics": {"title": "Analítica de palabras clave", "revenue": "Ingresos"},
-    "notifications": {"title": "Notificaciones", "markRead": "Marcar como leído"},
-    "ab": {
-        "title": "Pruebas A/B",
-        "name": "Nombre de prueba",
-        "variants": "Variantes separadas por coma",
-        "create": "Crear",
-        "variant": "Variante",
-        "impressions": "Impresiones",
-        "clicks": "Clics",
-        "rate": "Tasa de conversión",
-    },
 }

--- a/client/pages/social-generator.tsx
+++ b/client/pages/social-generator.tsx
@@ -1,0 +1,5 @@
+import SocialMediaGenerator from '../components/SocialMediaGenerator';
+
+export default function SocialGeneratorPage() {
+  return <SocialMediaGenerator />;
+}

--- a/client/services/socialGenerator.ts
+++ b/client/services/socialGenerator.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+export interface SocialPost {
+  caption: string;
+  image_url: string;
+}
+
+export async function generateSocialPost(prompt: string): Promise<SocialPost> {
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const res = await axios.post<SocialPost>(`${api}/social/post`, { prompt });
+  return res.data;
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -1,0 +1,37 @@
+# Internal Documentation
+
+## Social Media Generator Service
+
+The `social_generator` service provides an endpoint to create social media
+content from a text prompt. It returns a marketing caption and an image URL.
+
+### API
+
+- **POST `/social/post`**
+  - Body: `{ "prompt": string }`
+  - Response: `{ "caption": string, "image_url": string }`
+
+Behind the scenes the service calls the OpenAI integration client. When the
+`OPENAI_USE_STUB` environment variable is set or `OPENAI_API_KEY` is missing,
+stubbed responses are returned. The integration client implements basic retry
+logic for rate limits.
+
+### Flow
+
+```mermaid
+flowchart LR
+    A[Prompt] --> B[OpenAI Caption]
+    A --> C[OpenAI Image]
+    B --> D[Social Post]
+    C --> D
+```
+
+The task can also be executed asynchronously via the Celery task
+`generate_social_post_task`.
+
+## Frontend Page
+
+The `/social-generator` page renders the `SocialMediaGenerator` component. Users
+enter a prompt and the page displays the generated caption and image. The
+component uses the shared translation files and the design system classes for a
+responsive layout.

--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,0 +1,1 @@
+# Package root for shared modules

--- a/packages/integrations/__init__.py
+++ b/packages/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration client package."""

--- a/packages/integrations/openai.py
+++ b/packages/integrations/openai.py
@@ -1,0 +1,64 @@
+"""OpenAI integration helpers.
+
+These functions wrap calls to the OpenAI API.  If the
+``OPENAI_API_KEY`` environment variable is not set or
+``OPENAI_USE_STUB`` is truthy, deterministic stub responses are
+returned instead.  Simple retry logic handles rate limits (HTTP 429)
+with exponential backoff.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import httpx
+
+API_BASE = "https://api.openai.com/v1"
+API_KEY = os.getenv("OPENAI_API_KEY")
+USE_STUB = os.getenv("OPENAI_USE_STUB", "1").lower() in {"1", "true", "yes"}
+
+HEADERS = {"Authorization": f"Bearer {API_KEY}"} if API_KEY else {}
+
+
+async def _post(path: str, payload: dict[str, Any]) -> Any:
+    """POST helper with naive exponential backoff."""
+    if USE_STUB or not API_KEY:
+        raise RuntimeError("Real API calls disabled")
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        for attempt in range(3):
+            resp = await client.post(f"{API_BASE}{path}", headers=HEADERS, json=payload)
+            if resp.status_code == 429:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+    raise RuntimeError("OpenAI request failed after retries")
+
+
+async def generate_caption(prompt: str) -> str:
+    """Return a marketing caption for a given prompt."""
+    if USE_STUB or not API_KEY:
+        return f"Caption for: {prompt}"
+
+    data = await _post(
+        "/chat/completions",
+        {
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": prompt}],
+        },
+    )
+    return data["choices"][0]["message"]["content"].strip()
+
+
+async def generate_image(prompt: str) -> str:
+    """Return a URL to an image generated from the prompt."""
+    if USE_STUB or not API_KEY:
+        return "http://example.com/image.png"
+
+    data = await _post(
+        "/images/generations",
+        {"model": "gpt-image-1", "prompt": prompt, "size": "512x512"},
+    )
+    return data["data"][0]["url"]

--- a/services/social_generator/__init__.py
+++ b/services/social_generator/__init__.py
@@ -1,0 +1,3 @@
+from .api import app
+
+__all__ = ["app"]

--- a/services/social_generator/api.py
+++ b/services/social_generator/api.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .service import generate_post
+
+app = FastAPI()
+
+
+class Prompt(BaseModel):
+    prompt: str
+
+
+@app.post("/social/post")
+async def social_post(data: Prompt):
+    return await generate_post(data.prompt)

--- a/services/social_generator/service.py
+++ b/services/social_generator/service.py
@@ -1,0 +1,13 @@
+"""Business logic for social media content generation."""
+from __future__ import annotations
+
+from typing import Dict
+
+from packages.integrations.openai import generate_caption, generate_image
+
+
+async def generate_post(prompt: str) -> Dict[str, str]:
+    """Generate a caption and image for a social media post."""
+    caption = await generate_caption(prompt)
+    image_url = await generate_image(prompt)
+    return {"caption": caption, "image_url": image_url}

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -1,9 +1,11 @@
 import os
+import asyncio
 from celery import Celery
 from .trend_scraper.service import fetch_trends
 from .ideation.service import generate_ideas
 from .image_gen.service import generate_images
 from .integration.service import create_sku, publish_listing
+from .social_generator.service import generate_post
 
 CELERY_BROKER_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 celery_app = Celery("worker", broker=CELERY_BROKER_URL, backend=CELERY_BROKER_URL)
@@ -36,3 +38,9 @@ def create_sku_task(images):
 @celery_app.task
 def publish_listing_task(product):
     return publish_listing(product)
+
+
+@celery_app.task
+def generate_social_post_task(prompt: str):
+    """Celery task to create social media content."""
+    return asyncio.run(generate_post(prompt))

--- a/status.md
+++ b/status.md
@@ -10,20 +10,19 @@ This file tracks the remaining work required to bring PODPusher to production re
 ## Outstanding Tasks
 
 1. **Real Integrations** – Implement Printify and Etsy clients, replacing stubs in `services/integration/service.py`. Use environment variables for API keys and handle retries. Stripe billing integration also needs to be built for subscription plans.
-2. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
-3. **Analytics Enhancements** – Replace mocked analytics with real metrics collected from the database and user interactions.
-4. **Listing Composer Enhancements** – Finalise the character-count and tag-suggestion features; ensure they are merged and tested.
-5. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
-6. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
+2. **Analytics Enhancements** – Replace mocked analytics with real metrics collected from the database and user interactions.
+3. **Listing Composer Enhancements** – Finalise the character-count and tag-suggestion features; ensure they are merged and tested.
+4. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
+5. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
 
-7. **Documentation** – Update internal docs and API docs as new features are added.
-8. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-9. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
-10. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
-11. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-12. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
-13. Maintain architecture and schema diagrams.
-14. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+6. **Documentation** – Update internal docs and API docs as new features are added.
+7. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
+8. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
+9. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
+10. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+11. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
+12. Maintain architecture and schema diagrams.
+13. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
 
 ## Instructions to Agents
 

--- a/tests/e2e/social_generator.spec.ts
+++ b/tests/e2e/social_generator.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('social generator creates caption', async ({ page }) => {
+  await page.route('**/social/post', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ caption: 'hello', image_url: 'http://example.com/img.png' })
+    });
+  });
+  await page.goto('/social-generator');
+  await page.getByLabel('prompt').fill('idea');
+  await page.getByRole('button', { name: 'Generate' }).click();
+  await expect(page.getByText('hello')).toBeVisible();
+});

--- a/tests/test_social_generator.py
+++ b/tests/test_social_generator.py
@@ -1,0 +1,22 @@
+import asyncio
+from fastapi.testclient import TestClient
+
+from services.social_generator.api import app
+from services.social_generator.service import generate_post
+
+client = TestClient(app)
+
+
+def test_generate_post_api(monkeypatch):
+    monkeypatch.setenv("OPENAI_USE_STUB", "1")
+    resp = client.post("/social/post", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["caption"].startswith("Caption for: hello")
+    assert data["image_url"].startswith("http")
+
+
+def test_generate_post_service(monkeypatch):
+    monkeypatch.setenv("OPENAI_USE_STUB", "1")
+    result = asyncio.run(generate_post("hi"))
+    assert result["caption"].startswith("Caption for: hi")


### PR DESCRIPTION
## Summary
- add FastAPI `social_generator` service with OpenAI integration
- build SocialMediaGenerator page and component with i18n strings
- document service and expose Celery task and API client

## Testing
- `pytest tests/test_social_generator.py -q`
- `npm test -- SocialMediaGenerator.test.tsx`
- `npx playwright test tests/e2e/social_generator.spec.ts` *(fails: Needs playwright package)*


------
https://chatgpt.com/codex/tasks/task_e_688fd9615b70832bbec97fd03746e234