### PR TITLE
Add unit tests for integration stubs

### DIFF
--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -1,6 +1,10 @@
 
 # Internal Documentation
 
+## Integration Service Stubs
+
+Temporary stub implementations live in `services/integration/service.py`. Unit tests in `tests/test_integration_service.py` verify these stubs and should be removed once the real Printify and Etsy clients are integrated.
+
 ## Social Media Generator Service
 
 The `social_generator` service provides an endpoint to create social media

--- a/tests/test_integration_service.py
+++ b/tests/test_integration_service.py
@@ -1,0 +1,16 @@
+from services.integration import service
+
+
+def test_create_sku_returns_stub_when_no_api_key(monkeypatch):
+    monkeypatch.setattr(service, "PRINTIFY_API_KEY", None)
+    products = [{"title": "Test Product"}]
+    result = service.create_sku(products)
+    assert all(p["sku"] == "stub-sku" for p in result)
+
+
+def test_publish_listing_returns_stub_url_when_no_api_key(monkeypatch):
+    monkeypatch.setattr(service, "ETSY_API_KEY", None)
+    product = {"title": "Test Product"}
+    result = service.publish_listing(product)
+    assert result["etsy_url"] == "http://etsy.example/listing"
+    assert result["listing_url"] == "http://etsy.example/listing"


### PR DESCRIPTION
## Summary
- test Printify SKU creation stub returns `stub-sku` without API key
- test Etsy publish listing stub returns placeholder URL without API key
- document stub tests for future removal

## Testing
- `flake8 tests/test_integration_service.py`
- `pytest tests/test_integration_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe712e7ac832b9aec31d15985d19e