### PR TITLE
Add notification scheduling with delivery stubs

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -18,7 +18,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 
     axios
       .get(`${api}/api/notifications`, { headers: { 'X-User-Id': '1' } })
-      .then((res) => setUnread(res.data.filter((n: any) => !n.read).length))
+      .then((res) => setUnread(res.data.filter((n: any) => !n.read_status).length))
       .catch((err) => console.error(err));
   }, [api]);
 

--- a/client/pages/notifications.tsx
+++ b/client/pages/notifications.tsx
@@ -5,8 +5,9 @@ import { useTranslation } from 'next-i18next';
 export type Notification = {
   id: number;
   message: string;
+  type: string;
   created_at: string;
-  read: boolean;
+  read_status: boolean;
 };
 
 export default function Notifications() {
@@ -25,7 +26,7 @@ export default function Notifications() {
 
   const markRead = async (id: number) => {
     await axios.put(`${api}/api/notifications/${id}/read`);
-    setItems(items.map(n => (n.id === id ? { ...n, read: true } : n)));
+    setItems(items.map(n => (n.id === id ? { ...n, read_status: true } : n)));
   };
 
   return (
@@ -35,11 +36,11 @@ export default function Notifications() {
         {items.map(n => (
           <li
             key={n.id}
-            className={`p-2 border rounded ${n.read ? 'opacity-50' : ''}`}
+            className={`p-2 border rounded ${n.read_status ? 'opacity-50' : ''}`}
           >
             <div className="flex justify-between items-center">
-              <span>{n.message}</span>
-              {!n.read && (
+              <span>[{n.type}] {n.message}</span>
+              {!n.read_status && (
                 <button
                   data-testid={`read-${n.id}`}
                   onClick={() => markRead(n.id)}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,20 @@
+# Notifications & Scheduling
+
+This service delivers user-facing alerts and summaries.
+
+## Notification Types
+
+| Type   | Purpose                                     |
+| ------ | ------------------------------------------- |
+| system | Platform events such as quota resets        |
+| summary| Weekly trend highlights                     |
+| info   | General informational messages              |
+
+## Scheduling Behaviour
+
+An async scheduler enqueues recurring jobs:
+
+- **Monthly quota reset** – On the first day of each month at 00:00 UTC, user image quotas reset and a `system` notification is created.
+- **Weekly trending summary** – Every Monday at 00:00 UTC, the latest top trends are summarised and sent as `summary` notifications.
+
+Notifications are stored in the database and surfaced via the `/api/notifications` endpoints and UI bell icon. Delivery stubs exist for email and push channels; real integrations can replace them by providing API keys and setting `NOTIFY_USE_STUB=0`.

--- a/packages/integrations/notifications.py
+++ b/packages/integrations/notifications.py
@@ -1,0 +1,30 @@
+"""Notification delivery stubs.
+
+These helpers provide email and push notification functions. If the
+``NOTIFY_USE_STUB`` environment variable is truthy (default) or the
+required API keys are missing, the helpers merely print the payload
+instead of performing any network calls. This keeps tests fast and
+avoids external dependencies while allowing real integrations later.
+"""
+from __future__ import annotations
+
+import os
+
+
+USE_STUB = os.getenv("NOTIFY_USE_STUB", "1").lower() in {"1", "true", "yes"}
+
+
+def send_email(user_id: int, message: str, notif_type: str) -> None:
+    """Send an email notification or print a stub."""
+    if USE_STUB or not os.getenv("EMAIL_API_KEY"):
+        print(f"[stub email] user={user_id} type={notif_type} msg={message}")
+        return
+    raise NotImplementedError("Real email integration not configured")
+
+
+def send_push(user_id: int, message: str, notif_type: str) -> None:
+    """Send a push notification or print a stub."""
+    if USE_STUB or not os.getenv("PUSH_API_KEY"):
+        print(f"[stub push] user={user_id} type={notif_type} msg={message}")
+        return
+    raise NotImplementedError("Real push integration not configured")

--- a/services/models.py
+++ b/services/models.py
@@ -47,8 +47,9 @@ class Notification(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     user_id: int
     message: str
+    type: str = "info"
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    read: bool = False
+    read_status: bool = False
 
 
 class ABTest(SQLModel, table=True):

--- a/services/notifications/api.py
+++ b/services/notifications/api.py
@@ -18,6 +18,7 @@ async def start() -> None:
 
 class NotificationCreate(BaseModel):
     message: str
+    type: str = "info"
     user_id: int | None = None
 
 
@@ -32,7 +33,7 @@ async def create_notification_endpoint(
     x_user_id: str = Header(None, alias="X-User-Id"),
 ):
     user_id = payload.user_id or int(x_user_id)
-    return await create_notification(user_id, payload.message)
+    return await create_notification(user_id, payload.message, payload.type)
 
 
 @app.put("/{notification_id}/read")

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -5,7 +5,7 @@ test('notifications page lists items', async ({ page }) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify([{ id: 1, message: 'hello', read: false, created_at: '' }]),
+      body: JSON.stringify([{ id: 1, message: 'hello', type: 'info', read_status: false, created_at: '' }]),
     });
   });
 
@@ -13,7 +13,7 @@ test('notifications page lists items', async ({ page }) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ id: 1, message: 'hello', read: true, created_at: '' }),
+      body: JSON.stringify({ id: 1, message: 'hello', type: 'info', read_status: true, created_at: '' }),
     });
   });
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -12,19 +12,21 @@ async def test_notification_crud():
     await init_db()
     transport = ASGITransport(app=notif_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/", json={"message": "hello"}, headers={"X-User-Id": "1"})
+        resp = await client.post("/", json={"message": "hello", "type": "info"}, headers={"X-User-Id": "1"})
         assert resp.status_code == 200
         data = resp.json()
         assert data["message"] == "hello"
+        assert data["type"] == "info"
 
         resp = await client.get("/", headers={"X-User-Id": "1"})
         assert resp.status_code == 200
         notifs = resp.json()
         assert len(notifs) == 1
+        assert notifs[0]["read_status"] is False
 
         resp = await client.put(f"/{data['id']}/read")
         assert resp.status_code == 200
-        assert resp.json()["read"] is True
+        assert resp.json()["read_status"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand notification model with type and read_status fields
- queue monthly quota reset and weekly trend summary notifications
- add stub email/push delivery helpers and UI for unread counts
- document notification types and scheduler behaviour

## Testing
- `pytest tests/test_notifications.py`
- `npx --prefix client playwright test ../tests/e2e/notifications.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_688fe345d058832bb0b506b2c0e4b09a