### PR TITLE
feat: add tag suggestions and listing composer

### DIFF
--- a/client/components/ListingComposer.tsx
+++ b/client/components/ListingComposer.tsx
@@ -39,10 +39,11 @@ export default function ListingComposer({ onPublish }: Props) {
   return (
     <form onSubmit={submit} className="space-y-4">
       <div>
-        <label className="block text-sm font-medium mb-1">
+        <label htmlFor="title" className="block text-sm font-medium mb-1">
           {t('listings.title')} ({title.length}/140)
         </label>
         <input
+          id="title"
           className="border p-2 w-full"
           maxLength={140}
           value={title}
@@ -50,10 +51,11 @@ export default function ListingComposer({ onPublish }: Props) {
         />
       </div>
       <div>
-        <label className="block text-sm font-medium mb-1">
+        <label htmlFor="description" className="block text-sm font-medium mb-1">
           {t('listings.description')} ({description.length}/1000)
         </label>
         <textarea
+          id="description"
           className="border p-2 w-full"
           maxLength={1000}
           rows={4}

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -37,7 +37,8 @@
     "flag": "Flag as inappropriate"
   },
   "listings": {
-    "title": "Listing Composer",
+    "pageTitle": "Listing Composer",
+    "title": "Title",
     "description": "Description",
     "tags": "Tags",
     "suggest": "Suggest Tags",

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -37,7 +37,8 @@
     "flag": "Marcar como inapropiado"
   },
   "listings": {
-    "title": "Compositor de publicaciones",
+    "pageTitle": "Compositor de publicaciones",
+    "title": "Título",
     "description": "Descripción",
     "tags": "Etiquetas",
     "suggest": "Sugerir etiquetas",

--- a/client/pages/listings.tsx
+++ b/client/pages/listings.tsx
@@ -5,7 +5,7 @@ export default function Listings() {
   const { t } = useTranslation('common');
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold">{t('listings.title')}</h1>
+      <h1 className="text-2xl font-bold">{t('listings.pageTitle')}</h1>
       <ListingComposer />
     </div>
   );

--- a/client/services/listings.ts
+++ b/client/services/listings.ts
@@ -2,6 +2,6 @@ import axios from 'axios';
 
 export async function fetchTagSuggestions(title: string, description: string): Promise<string[]> {
   const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  const res = await axios.post<string[]>(`${api}/suggest-tags`, { title, description });
+  const res = await axios.post<string[]>(`${api}/api/ideation/suggest-tags`, { title, description });
   return res.data;
 }

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -36,6 +36,23 @@ The `/social-generator` page renders the `SocialMediaGenerator` component. Users
 enter a prompt and the page displays the generated caption and image. The
 component uses the shared translation files and the design system classes for a
 responsive layout.
+
+## Listing Composer
+
+The `ideation` service exposes a tag suggestion helper for Etsy listings. It
+inspects the listing title and description and returns up to 13 concise tags.
+
+### API
+
+- **POST `/api/ideation/suggest-tags`**
+  - Body: `{ "title": string, "description": string }`
+  - Response: `string[]` of tag suggestions
+
+### Frontend Page
+
+The `/listings` page renders the `ListingComposer` component. Users type a title
+and description, see character counters update in real time and can request tag
+suggestions which populate clickable chips for easy selection.
 =======
 # Analytics Service
 

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -6,7 +6,8 @@ from ..trend_scraper.service import (
     get_design_ideas,
     get_product_suggestions,
 )
-from ..ideation.service import generate_ideas, suggest_tags
+from ..ideation.service import generate_ideas
+from ..ideation.api import app as ideation_app
 from ..image_gen.service import generate_images
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
@@ -21,6 +22,7 @@ app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
 app.mount("/api/search", search_app)
 app.mount("/ab_tests", ab_app)
+app.mount("/api/ideation", ideation_app)
 app.add_middleware(AnalyticsMiddleware)
 
 
@@ -51,10 +53,3 @@ async def design_ideas(category: str | None = None):
 @app.get("/product-suggestions")
 async def product_suggestions(category: str | None = None, design: str | None = None):
     return get_product_suggestions(category, design)
-
-
-@app.post("/suggest-tags")
-async def suggest_tags_endpoint(data: dict):
-    title = data.get("title", "")
-    description = data.get("description", "")
-    return suggest_tags(title, description)

--- a/services/ideation/api.py
+++ b/services/ideation/api.py
@@ -21,4 +21,4 @@ async def ideas(data: TrendList):
 
 @app.post("/suggest-tags")
 async def tags(data: ListingData):
-    return suggest_tags(data.title, data.description)
+    return await suggest_tags(data.title, data.description)

--- a/services/ideation/service.py
+++ b/services/ideation/service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ..models import Idea
 from ..common.database import get_session
 from ..trend_scraper.events import EVENTS
+from packages.integrations import openai
 
 
 TrendInput = Union[str, Dict]
@@ -66,9 +67,14 @@ async def generate_ideas(trends: List[TrendInput]) -> List[Dict]:
     return ideas
 
 
-def suggest_tags(title: str, description: str) -> List[str]:
+async def suggest_tags(title: str, description: str) -> List[str]:
     """Return a list of up to 13 tag suggestions based on title and description."""
-    text = f"{title} {description}"
+    text = f"{title} {description}".strip()
+    if openai.API_KEY and not openai.USE_STUB:
+        try:
+            return await openai.suggest_tags(text)
+        except Exception:
+            pass
     words = [w.strip(".,!?:;\"'()[]{}").lower() for w in text.split()]
     stop = {
         "the",

--- a/status.md
+++ b/status.md
@@ -12,19 +12,18 @@ This file tracks the remaining work required to bring PODPusher to production re
 1. **Real Integrations** – Implement Printify and Etsy clients, replacing stubs in `services/integration/service.py`. Use environment variables for API keys and handle retries. Stripe billing integration also needs to be built for subscription plans.
 
 2. **Analytics Enhancements** – Replace mocked analytics with real metrics collected from the database and user interactions.
-3. **Listing Composer Enhancements** – Finalise the character-count and tag-suggestion features; ensure they are merged and tested.
-4. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
-5. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
+3. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
+4. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
 
-6. **Documentation** – Update internal docs and API docs as new features are added.
-7. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-8. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
-9. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
-10. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-11. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
-12. Maintain architecture and schema diagrams.
-13. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
-14. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
+5. **Documentation** – Update internal docs and API docs as new features are added.
+6. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
+7. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
+8. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
+9. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+10. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
+11. Maintain architecture and schema diagrams.
+12. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+13. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
 
 
 ## Instructions to Agents

--- a/tests/e2e/listings.spec.ts
+++ b/tests/e2e/listings.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('listing composer suggests tags', async ({ page }) => {
+  await page.route('**/api/ideation/suggest-tags', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(['funny', 'dog'])
+    });
+  });
+  await page.goto('/listings');
+  await page.getByLabel('Title').fill('Funny Dog Shirt');
+  await page.getByLabel('Description').fill('A hilarious t-shirt');
+  await page.getByRole('button', { name: 'Suggest Tags' }).click();
+  await expect(page.getByRole('button', { name: 'funny' })).toBeVisible();
+  await page.getByRole('button', { name: 'funny' }).click();
+  await expect(page.getByText('Tags (1/13)')).toBeVisible();
+});

--- a/tests/test_tag_suggestions.py
+++ b/tests/test_tag_suggestions.py
@@ -7,7 +7,7 @@ from services.ideation.service import suggest_tags
 
 @pytest.mark.asyncio
 async def test_suggest_tags_function():
-    tags = suggest_tags("Funny Dog Shirt", "This is a hilarious dog t-shirt")
+    tags = await suggest_tags("Funny Dog Shirt", "This is a hilarious dog t-shirt")
     assert "funny" in tags
     assert "dog" in tags
     assert len(tags) <= 13
@@ -18,7 +18,7 @@ async def test_suggest_tags_endpoint():
     transport = ASGITransport(app=gateway_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
-            "/suggest-tags",
+            "/api/ideation/suggest-tags",
             json={"title": "Cat Mug", "description": "Cute cat coffee mug"},
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add OpenAI-backed tag suggestion helper with heuristic fallback
- mount ideation API and expose tag suggestion endpoint to frontend
- build Listing Composer UI with translations and tag selection

## Testing
- `pytest`
- `npx --prefix client playwright test tests/e2e/listings.spec.ts --config=playwright.config.ts` *(fails: ENETUNREACH in Next.js dev server)*

------
https://chatgpt.com/codex/tasks/task_e_688fe33ae64c832bab2b0206e3303c60