### PR TITLE
feat: implement user plan quotas

### DIFF
--- a/client/__tests__/QuotaDisplay.test.tsx
+++ b/client/__tests__/QuotaDisplay.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuotaDisplay from '../components/QuotaDisplay';
+import * as userService from '../services/user';
+
+jest.mock('../services/user');
+
+const mockedFetch = userService.fetchPlan as jest.Mock;
+
+test('shows remaining credits', async () => {
+  mockedFetch.mockResolvedValue({ plan: 'free', quota_used: 5, limit: 20 });
+  render(<QuotaDisplay />);
+  await waitFor(() =>
+    expect(screen.getByTestId('quota')).toHaveTextContent('15/20')
+  );
+});
+
+test('warns when near limit', async () => {
+  mockedFetch.mockResolvedValue({ plan: 'free', quota_used: 19, limit: 20 });
+  render(<QuotaDisplay />);
+  await waitFor(() =>
+    expect(screen.getByTestId('quota')).toHaveClass('text-red-500')
+  );
+});

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -3,19 +3,14 @@ import { ReactNode, useEffect, useState } from 'react';
 import axios from 'axios';
 import { useTranslation } from 'next-i18next';
 import LanguageSwitcher from './LanguageSwitcher';
+import QuotaDisplay from './QuotaDisplay';
 
 export default function Layout({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common');
-  const [usage, setUsage] = useState<{ plan: string; images_used: number; limit: number } | null>(null);
   const [unread, setUnread] = useState(0);
   const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
   useEffect(() => {
-    axios
-      .get(`${api}/api/user/plan`, { headers: { 'X-User-Id': '1' } })
-      .then((res) => setUsage(res.data))
-      .catch((err) => console.error(err));
-
     axios
       .get(`${api}/api/notifications`, { headers: { 'X-User-Id': '1' } })
       .then((res) => setUnread(res.data.filter((n: any) => !n.read).length))
@@ -49,9 +44,7 @@ export default function Layout({ children }: { children: ReactNode }) {
               </span>
             )}
           </Link>
-          <span className="ml-auto text-sm" data-testid="quota">
-            {usage ? `${usage.images_used}/${usage.limit} images` : ''}
-          </span>
+          <QuotaDisplay />
         </div>
       </nav>
       <main className="flex-1 container mx-auto p-4">{children}</main>

--- a/client/components/QuotaDisplay.tsx
+++ b/client/components/QuotaDisplay.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { fetchPlan, PlanUsage } from '../services/user';
+
+export default function QuotaDisplay() {
+  const [usage, setUsage] = useState<PlanUsage | null>(null);
+
+  useEffect(() => {
+    fetchPlan().then(setUsage).catch((err) => console.error(err));
+  }, []);
+
+  if (!usage) {
+    return <span data-testid="quota" />;
+  }
+
+  const remaining = usage.limit - usage.quota_used;
+  const warn = remaining <= usage.limit * 0.1;
+
+  return (
+    <span
+      data-testid="quota"
+      className={`ml-auto text-sm ${warn ? 'text-red-500' : ''}`}
+    >
+      {`${remaining}/${usage.limit} credits`}
+    </span>
+  );
+}

--- a/client/services/user.ts
+++ b/client/services/user.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+
+const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+export interface PlanUsage {
+  plan: string;
+  quota_used: number;
+  limit: number;
+}
+
+export async function fetchPlan(): Promise<PlanUsage> {
+  const res = await axios.get<PlanUsage>(`${api}/api/user/plan`, {
+    headers: { 'X-User-Id': '1' },
+  });
+  return res.data;
+}
+
+export async function incrementQuota(count: number): Promise<PlanUsage> {
+  const res = await axios.post<PlanUsage>(
+    `${api}/api/user/plan`,
+    { count },
+    { headers: { 'X-User-Id': '1' } }
+  );
+  return res.data;
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -62,3 +62,23 @@ Mount the middleware on additional services as needed:
 from services.analytics.middleware import AnalyticsMiddleware
 app.add_middleware(AnalyticsMiddleware)
 
+```
+
+## User Plans and Quotas
+
+The platform tracks usage limits per subscription plan and exposes endpoints
+for the dashboard to display remaining credits.
+
+### API
+
+- **GET `/api/user/plan`** – returns `{ plan, quota_used, limit }` and resets
+  monthly usage when needed.
+- **POST `/api/user/plan`** – increment usage by `count`; returns updated
+  `{ plan, quota_used, limit }` or 403 when the quota would be exceeded.
+
+### Frontend
+
+The `QuotaDisplay` component in the dashboard navigation calls the GET endpoint
+via a typed client and shows the remaining credits. When fewer than 10 % of
+credits remain, the counter turns red to warn the user.
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   webServer: {
-    command: 'npm run dev --prefix client',
+    command: 'npm run build --prefix client && npm run start --prefix client',
     port: 3000,
     timeout: 120 * 1000,
     reuseExistingServer: true,
+    env: { NEXT_DISABLE_VERSION_CHECK: '1' },
   },
   testDir: './tests/e2e',
   use: {

--- a/services/models.py
+++ b/services/models.py
@@ -39,7 +39,7 @@ class Listing(SQLModel, table=True):
 class User(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     plan: str = "free"
-    images_used: int = 0
+    quota_used: int = 0
     last_reset: datetime = Field(default_factory=datetime.utcnow)
 
 

--- a/services/notifications/service.py
+++ b/services/notifications/service.py
@@ -60,7 +60,7 @@ async def reset_monthly_quotas() -> None:
         users = result.all()
         ids = [u.id for u in users]
         for u in users:
-            u.images_used = 0
+            u.quota_used = 0
             u.last_reset = now
             session.add(u)
         await session.commit()

--- a/services/user/api.py
+++ b/services/user/api.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from fastapi import FastAPI, Header
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
 from ..common.database import get_session
 from ..models import User
 from ..common.quotas import PLAN_LIMITS
@@ -7,7 +8,7 @@ from ..common.quotas import PLAN_LIMITS
 app = FastAPI()
 
 
-@app.get("/user/plan")
+@app.get("/api/user/plan")
 async def user_plan(x_user_id: str = Header(..., alias="X-User-Id")):
     async with get_session() as session:
         user = await session.get(User, int(x_user_id))
@@ -19,10 +20,33 @@ async def user_plan(x_user_id: str = Header(..., alias="X-User-Id")):
             await session.refresh(user)
         else:
             if user.last_reset.month != now.month or user.last_reset.year != now.year:
-                user.images_used = 0
+                user.quota_used = 0
                 user.last_reset = now
                 session.add(user)
                 await session.commit()
                 await session.refresh(user)
         limit = PLAN_LIMITS.get(user.plan, PLAN_LIMITS["free"])
-        return {"plan": user.plan, "images_used": user.images_used, "limit": limit}
+        return {"plan": user.plan, "quota_used": user.quota_used, "limit": limit}
+
+
+class QuotaUpdate(BaseModel):
+    count: int
+
+
+@app.post("/api/user/plan")
+async def increment_quota(data: QuotaUpdate, x_user_id: str = Header(..., alias="X-User-Id")):
+    async with get_session() as session:
+        user = await session.get(User, int(x_user_id))
+        if not user:
+            user = User(id=int(x_user_id))
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+        limit = PLAN_LIMITS.get(user.plan, PLAN_LIMITS["free"])
+        if user.quota_used + data.count > limit:
+            raise HTTPException(status_code=403, detail="Quota exceeded")
+        user.quota_used += data.count
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return {"plan": user.plan, "quota_used": user.quota_used, "limit": limit}

--- a/status.md
+++ b/status.md
@@ -4,7 +4,6 @@ This file tracks the remaining work required to bring PODPusher to production re
 
 ## Pending PRs
 
-- **User Plans & Quotas PR** – Coming from the `feat/user-quota-merge` branch via Codex. Review and merge once it passes tests.
 - **Image Review & Tagging PR** – Coming from the `feat/image-review-merge` branch via Codex. Review and merge once complete.
 
 ## Outstanding Tasks

--- a/tests/e2e/quota.spec.ts
+++ b/tests/e2e/quota.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { spawn, ChildProcess } from 'child_process';
+
+const api = 'http://localhost:8000';
+let server: ChildProcess;
+
+test.beforeAll(async () => {
+  await new Promise((resolve) => {
+    const init = spawn('python', [
+      '-c',
+      'import asyncio; from services.common.database import init_db; asyncio.run(init_db())',
+    ]);
+    init.on('exit', resolve);
+  });
+  server = spawn('python', ['-m', 'uvicorn', 'services.image_gen.api:app', '--port', '8000']);
+  await new Promise((r) => setTimeout(r, 1000));
+});
+
+test.afterAll(() => {
+  server.kill();
+});
+
+test('requests under quota succeed', async ({ request }) => {
+  const uid = '301';
+  for (let i = 0; i < 2; i++) {
+    const res = await request.post(`${api}/images`, {
+      data: { ideas: ['idea'] },
+      headers: { 'X-User-Id': uid },
+    });
+    expect(res.status()).toBe(200);
+  }
+});
+
+test('requests beyond quota are blocked', async ({ request }) => {
+  const uid = '302';
+  for (let i = 0; i < 20; i++) {
+    const res = await request.post(`${api}/images`, {
+      data: { ideas: ['idea'] },
+      headers: { 'X-User-Id': uid },
+    });
+    expect(res.status()).toBe(200);
+  }
+  const res = await request.post(`${api}/images`, {
+    data: { ideas: ['idea'] },
+    headers: { 'X-User-Id': uid },
+  });
+  expect(res.status()).toBe(403);
+});

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -31,7 +31,7 @@ async def test_notification_crud():
 async def test_scheduler_jobs(monkeypatch):
     await init_db()
     async with get_session() as session:
-        user = User(id=1, images_used=5)
+        user = User(id=1, quota_used=5)
         session.add(user)
         await session.commit()
 
@@ -43,7 +43,7 @@ async def test_scheduler_jobs(monkeypatch):
     await reset_monthly_quotas()
     async with get_session() as session:
         user = await session.get(User, 1)
-        assert user.images_used == 0
+        assert user.quota_used == 0
 
     await weekly_trending_summary()
     transport = ASGITransport(app=notif_app)

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -25,4 +25,4 @@ async def test_quota_enforcement():
             if i < 20:
                 assert resp.status_code == 200
             else:
-                assert resp.status_code == 402
+                assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- track user quotas and plan limits in backend
- display remaining credits in navbar with warning state
- add tests for quota middleware and plan endpoints

## Testing
- `pytest`
- `npm test --prefix client`
- `npx playwright test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_688fe32c7ad8832ba10abc0bf47cc825