### PR TITLE
feat: rework search with db filtering and i18n

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ReactNode, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import axios from 'axios';
 import { useTranslation } from 'next-i18next';
 import LanguageSwitcher from './LanguageSwitcher';
@@ -8,7 +9,9 @@ import QuotaDisplay from './QuotaDisplay';
 export default function Layout({ children }: { children: ReactNode }) {
   const { t } = useTranslation('common');
   const [unread, setUnread] = useState(0);
+  const [navQuery, setNavQuery] = useState('');
   const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const router = useRouter();
 
   useEffect(() => {
     axios
@@ -31,6 +34,21 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <Link href="/social-generator" className="hover:underline">{t('nav.socialGenerator')}</Link>
           <Link href="/ab_tests" className="hover:underline">{t('nav.abTests')}</Link>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              router.push(`/search?q=${encodeURIComponent(navQuery)}`);
+              setNavQuery('');
+            }}
+            className="flex items-center ml-auto"
+          >
+            <input
+              value={navQuery}
+              onChange={(e) => setNavQuery(e.target.value)}
+              placeholder={t('nav.searchPlaceholder')}
+              className="p-1 rounded text-black"
+            />
+          </form>
           <LanguageSwitcher />
           <Link
             href="/notifications"

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -10,7 +10,8 @@
     "listings": "Listings",
     "abTests": "A/B Tests",
     "notifications": "Notifications",
-    "socialGenerator": "Social Generator"
+    "socialGenerator": "Social Generator",
+    "searchPlaceholder": "Search..."
   },
   "index": { "trending": "Trending Keywords", "events": "This Month's Events" },
   "categories": { "title": "Trending Categories" },
@@ -60,6 +61,17 @@
     "title": "Social Media Generator",
     "prompt": "Enter caption idea",
     "button": "Generate"
-
+  },
+  "search": {
+    "title": "Search",
+    "keywordPlaceholder": "Keyword",
+    "allCategories": "All Categories",
+    "tagPlaceholder": "Tag",
+    "rating": "Rating",
+    "button": "Search",
+    "loading": "Loading...",
+    "results": "{{count}} results",
+    "ratingLabel": "Rating: {{rating}}",
+    "noResults": "No results found"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -10,7 +10,8 @@
     "listings": "Publicaciones",
     "abTests": "Pruebas A/B",
     "notifications": "Notificaciones",
-    "socialGenerator": "Generador Social"
+    "socialGenerator": "Generador Social",
+    "searchPlaceholder": "Buscar..."
   },
   "index": { "trending": "Palabras clave en tendencia", "events": "Eventos del mes" },
   "categories": { "title": "Categorías en tendencia" },
@@ -60,6 +61,17 @@
     "title": "Generador de Redes Sociales",
     "prompt": "Introduce una idea de caption",
     "button": "Generar"
-
+  },
+  "search": {
+    "title": "Buscar",
+    "keywordPlaceholder": "Palabra clave",
+    "allCategories": "Todas las categorías",
+    "tagPlaceholder": "Etiqueta",
+    "rating": "Calificación",
+    "button": "Buscar",
+    "loading": "Cargando...",
+    "results": "{{count}} resultados",
+    "ratingLabel": "Calificación: {{rating}}",
+    "noResults": "Sin resultados"
   }
 }

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -103,3 +103,15 @@ The `QuotaDisplay` component in the dashboard navigation calls the GET endpoint
 via a typed client and shows the remaining credits. When fewer than 10 % of
 credits remain, the counter turns red to warn the user.
 
+## Advanced Search Service
+
+The `search` service exposes a `/api/search` endpoint supporting keyword,
+category, tag and rating filters. Queries are translated into SQL so filtering
+and pagination occur at the database layer. The endpoint returns `{ items,
+total, page, page_size }` allowing the UI to display result counts and paginate
+efficiently.
+
+On the frontend, the `/search` page provides controls for each filter and
+consumes the endpoint. The navbar now includes a quick search box which routes
+to the page and pre-fills the query parameter.
+

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,11 +1,30 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 from .service import search_products
+
+
+class SearchItem(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    image_url: str
+    rating: int | None = None
+    tags: list[str] = []
+    category: str
+
+
+class SearchResponse(BaseModel):
+    items: list[SearchItem]
+    total: int
+    page: int
+    page_size: int
+
 
 app = FastAPI()
 
 
-@app.get("/")
+@app.get("/", response_model=SearchResponse)
 async def search(
     q: str | None = None,
     category: str | None = None,

--- a/status.md
+++ b/status.md
@@ -16,13 +16,12 @@ This file tracks the remaining work required to bring PODPusher to production re
 
 5. **Documentation** – Update internal docs and API docs as new features are added.
 6. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-7. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
-8. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
-9. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-10. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
-11. Maintain architecture and schema diagrams.
-12. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
-13. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
+7. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
+8. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+9. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
+10. Maintain architecture and schema diagrams.
+11. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+12. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
 
 
 ## Instructions to Agents

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -13,17 +13,20 @@ test('search page filters products', async ({ page }) => {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify([
-        {
-          id: 1,
-          name: 'Product 1',
-          description: 'funny dog shirt',
-          image_url: '/test.png',
-          rating: 4,
-          tags: ['funny'],
-          category: 'apparel',
-        },
-      ]),
+      body: JSON.stringify({
+        items: [
+          {
+            id: 1,
+            name: 'Product 1',
+            description: 'funny dog shirt',
+            image_url: '/test.png',
+            rating: 4,
+            tags: ['funny'],
+            category: 'apparel',
+          },
+        ],
+        total: 1,
+      }),
     });
   });
 

--- a/tests/test_search_api.py
+++ b/tests/test_search_api.py
@@ -31,9 +31,14 @@ async def test_search_api_endpoint():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
             "/api/search/",
-            params={"q": "cat", "category": "accessories", "tag": "cute", "rating_min": 4},
+            params={
+                "q": "cat",
+                "category": "accessories",
+                "tag": "cute",
+                "rating_min": 4,
+            },
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["image_url"] == "img.png"
+        assert data["total"] == 1
+        assert data["items"][0]["image_url"] == "img.png"

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -27,6 +27,8 @@ async def test_search_service_filters():
         await session.commit()
         await session.refresh(product)
 
-    results = await search_products(q="dog", category="apparel", tag="funny", rating_min=3)
-    assert len(results) == 1
-    assert results[0]["id"] == product.id
+    results = await search_products(
+        q="dog", category="apparel", tag="funny", rating_min=3
+    )
+    assert results["total"] == 1
+    assert results["items"][0]["id"] == product.id


### PR DESCRIPTION
## Summary
- implement database-backed filtering and pagination for search service
- localize search UI and add navbar search box
- document advanced search architecture and update status

## Testing
- `npm test --prefix client`
- `pytest tests/test_search_service.py tests/test_search_api.py`
- `npx playwright test tests/e2e/search.spec.ts` *(fails: Cannot find module '@playwright/test')*
- `pytest` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dcc5a6a4832bb42c50d3a2c2728d