### PR TITLE
Re-implement A/B testing support v3

### DIFF
--- a/client/__tests__/ABTestsPage.test.tsx
+++ b/client/__tests__/ABTestsPage.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import axios from 'axios';
+import ABTests from '../pages/ab_tests';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key.split('.').pop() })
+}));
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+test('submits experiment with weights', async () => {
+  mockedAxios.post.mockResolvedValueOnce({ data: { id: 1 } });
+  mockedAxios.get.mockResolvedValueOnce({ data: [] });
+  render(<ABTests metrics={[]} />);
+  fireEvent.change(screen.getByPlaceholderText('name'), { target: { value: 'Test' } });
+  fireEvent.change(screen.getByPlaceholderText('variants'), { target: { value: 'A,B' } });
+  fireEvent.change(screen.getByPlaceholderText('weights'), { target: { value: '0.6,0.4' } });
+  fireEvent.click(screen.getByText('create'));
+  expect(mockedAxios.post).toHaveBeenCalledWith(
+    expect.stringContaining('/ab_tests'),
+    expect.objectContaining({
+      name: 'Test',
+      variants: ['A', 'B'],
+      experiment_type: 'image',
+      traffic_split: [0.6, 0.4],
+    })
+  );
+});

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -54,7 +54,12 @@
     "variant": "Variant",
     "impressions": "Impressions",
     "clicks": "Clicks",
-    "rate": "Conversion Rate"
+    "rate": "Conversion Rate",
+    "type": "Experiment Type",
+    "weights": "Traffic Split (comma separated)",
+    "start": "Start Time",
+    "end": "End Time",
+    "weight": "Weight"
   },
   "social": {
     "title": "Social Media Generator",

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -54,7 +54,12 @@
     "variant": "Variante",
     "impressions": "Impresiones",
     "clicks": "Clics",
-    "rate": "Tasa de conversión"
+    "rate": "Tasa de conversión",
+    "type": "Tipo de experimento",
+    "weights": "División de tráfico (separada por comas)",
+    "start": "Inicio",
+    "end": "Fin",
+    "weight": "Peso"
   },
   "social": {
     "title": "Generador de Redes Sociales",

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -103,3 +103,18 @@ The `QuotaDisplay` component in the dashboard navigation calls the GET endpoint
 via a typed client and shows the remaining credits. When fewer than 10 % of
 credits remain, the counter turns red to warn the user.
 
+## A/B Testing Engine
+
+The `ab_tests` service enables experiments on listing attributes such as images,
+descriptions and pricing. Each experiment defines variant traffic weights and
+optional start/end times for scheduling. Metrics for impressions and clicks are
+recorded per variant and surfaced via API and dashboard.
+
+```mermaid
+flowchart LR
+    A[Configure Experiment] --> B[AB Test Service]
+    B --> C[Listing Publisher]
+    C --> D[(Metrics)]
+    D --> B
+```
+

--- a/services/ab_tests/api.py
+++ b/services/ab_tests/api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from datetime import datetime
 
 from .service import (
     create_test,
@@ -15,11 +16,22 @@ app = FastAPI()
 class TestCreate(BaseModel):
     name: str
     variants: list[str]
+    experiment_type: str
+    traffic_split: list[float] | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
 
 
 @app.post("/")
 async def create(payload: TestCreate):
-    return await create_test(payload.name, payload.variants)
+    return await create_test(
+        payload.name,
+        payload.variants,
+        payload.experiment_type,
+        payload.traffic_split,
+        payload.start_time,
+        payload.end_time,
+    )
 
 
 @app.get("/metrics")

--- a/services/models.py
+++ b/services/models.py
@@ -2,6 +2,7 @@ from typing import Optional, List, Dict, Any
 from sqlmodel import SQLModel, Field
 from sqlalchemy import Column, JSON
 from datetime import datetime
+from enum import Enum
 
 
 class Trend(SQLModel, table=True):
@@ -52,11 +53,22 @@ class Notification(SQLModel, table=True):
     read_status: bool = False
 
 
+class ExperimentType(str, Enum):
+    """Supported experiment dimensions."""
+
+    IMAGE = "image"
+    DESCRIPTION = "description"
+    PRICING = "pricing"
+
+
 class ABTest(SQLModel, table=True):
     """Top level A/B test container."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str
+    experiment_type: ExperimentType
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
@@ -66,6 +78,7 @@ class ABVariant(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     test_id: int
     name: str
+    traffic_weight: float = 1.0
     impressions: int = 0
     clicks: int = 0
 

--- a/status.md
+++ b/status.md
@@ -17,7 +17,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 5. **Documentation** – Update internal docs and API docs as new features are added.
 6. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
 7. **Advanced Search & Filtering** – Build a `/api/search` endpoint with filtering options (category, trend, rating) and add a search page with filter controls.
-8. **A/B Testing Support** – Create a model and API for A/B tests, enabling sellers to compare titles, descriptions and tags; include UI to set up tests and view metrics.
+8. **A/B Testing Engine** – Supports image, description and pricing experiments with schedulable start/end dates and dynamic traffic splitting. UI and API allow configuration and metrics viewing.
 9. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 10. **Localization & Internationalization (i18n)** – Integrate translation support (e.g., next-i18next), provide a language switcher in the UI and adapt currency formats for different locales.
 11. Maintain architecture and schema diagrams.

--- a/tests/test_ab_tests_api.py
+++ b/tests/test_ab_tests_api.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from services.ab_tests.api import app as ab_app
 from services.common.database import init_db
+from datetime import datetime, timedelta
 
 
 @pytest.mark.asyncio
@@ -9,7 +10,19 @@ async def test_ab_tests_api():
     await init_db()
     transport = ASGITransport(app=ab_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/", json={"name": "Test", "variants": ["A"]})
+        start = datetime.utcnow().isoformat()
+        end = (datetime.utcnow() + timedelta(days=1)).isoformat()
+        resp = await client.post(
+            "/",
+            json={
+                "name": "Test",
+                "variants": ["A", "B"],
+                "experiment_type": "description",
+                "traffic_split": [0.5, 0.5],
+                "start_time": start,
+                "end_time": end,
+            },
+        )
         assert resp.status_code == 200
         data = resp.json()
         vid = data["variants"][0]["id"]
@@ -20,5 +33,6 @@ async def test_ab_tests_api():
         resp = await client.get(f"/{data['id']}/metrics")
         assert resp.status_code == 200
         metrics = resp.json()
-        assert len(metrics) == 1
+        assert len(metrics) == 2
+        assert metrics[0]["traffic_weight"] == 0.5
         assert metrics[0]["clicks"] == 1

--- a/tests/test_ab_tests_service.py
+++ b/tests/test_ab_tests_service.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, timedelta
 from services.ab_tests.service import (
     create_test,
     get_metrics,
@@ -11,10 +12,22 @@ from services.common.database import init_db
 @pytest.mark.asyncio
 async def test_ab_service_flow():
     await init_db()
-    test = await create_test("Example", ["A", "B"])
+    start = datetime.utcnow()
+    end = start + timedelta(days=1)
+    test = await create_test(
+        "Example",
+        ["A", "B"],
+        "image",
+        [0.6, 0.4],
+        start,
+        end,
+    )
     assert test["name"] == "Example"
+    assert test["experiment_type"] == "image"
     assert len(test["variants"]) == 2
+    assert test["start_time"]
     vid = test["variants"][0]["id"]
+    assert test["variants"][0]["traffic_weight"] == pytest.approx(0.6)
     await record_impression(vid)
     await record_click(vid)
     metrics = await get_metrics(test["id"])


### PR DESCRIPTION
## Summary
- add experiment type, traffic weights, and scheduling to A/B tests
- expose extended creation API and enrich dashboard UI with new fields and metrics
- document A/B test architecture and update status

## Testing
- `pytest`
- `npm --prefix client test`
- `npx playwright test tests/e2e/ab_tests.spec.ts` *(fails: playwright@1.55.0 installation prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dd0ce6e0832b8e1e5aa05df0a49f