### PR TITLE
Implement analytics enhancements

### DIFF
--- a/client/__tests__/AnalyticsPage.test.tsx
+++ b/client/__tests__/AnalyticsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import axios from 'axios';
@@ -18,13 +18,16 @@ jest.mock('react-chartjs-2', () => ({
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const initialData: SummaryRecord[] = [{ path: '/home', count: 1 }];
+const initialData: SummaryRecord[] = [
+  { path: '/home', views: 1, clicks: 0, conversions: 0, conversion_rate: 0 },
+];
 
-it('renders analytics chart and changes filter', async () => {
+it('renders analytics charts and refreshes', async () => {
+  jest.useFakeTimers();
+  mockedAxios.get.mockResolvedValue({ data: initialData });
   render(<Analytics initialData={initialData} />);
-  expect(screen.getByTestId('chart')).toBeInTheDocument();
-  const select = screen.getByLabelText('analytics.filter');
-  mockedAxios.get.mockResolvedValueOnce({ data: [{ path: '/prod', count: 2 }] });
-  fireEvent.change(select, { target: { value: 'click' } });
-  await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledTimes(1));
+  expect(screen.getAllByTestId('chart')).toHaveLength(3);
+  jest.advanceTimersByTime(5000);
+  await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+  jest.useRealTimers();
 });

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -55,7 +55,9 @@
     "language": "Language"
   },
   "analytics": {
-    "title": "Keyword Analytics",
+    "title": "Analytics Dashboard",
+    "views": "Page Views",
+    "conversionRate": "Conversion Rate",
     "revenue": "Revenue"
   },
   "notifications": {

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -55,7 +55,9 @@
     "language": "Idioma"
   },
   "analytics": {
-    "title": "Analítica de palabras clave",
+    "title": "Panel de Analítica",
+    "views": "Vistas de página",
+    "conversionRate": "Tasa de conversión",
     "revenue": "Ingresos"
   },
   "notifications": {

--- a/client/pages/analytics.tsx
+++ b/client/pages/analytics.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import dynamic from 'next/dynamic';
 import { useTranslation } from 'next-i18next';
-import { useState } from 'react';
 import { fetchSummary } from '../services/analytics';
 
 const Bar = dynamic(() => import('react-chartjs-2').then((mod) => mod.Bar), { ssr: false });
 
 export type SummaryRecord = {
   path: string;
-  count: number;
+  views: number;
+  clicks: number;
+  conversions: number;
+  conversion_rate: number;
 };
 
 interface AnalyticsProps {
@@ -18,27 +20,47 @@ interface AnalyticsProps {
 
 export default function Analytics({ initialData }: AnalyticsProps) {
   const { t } = useTranslation('common');
-  const [eventType, setEventType] = useState('page_view');
   const [data, setData] = useState<SummaryRecord[]>(initialData);
 
-  const fetchData = async (type: string) => {
-    const res = await fetchSummary(type);
-    setData(res);
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const res = await fetchSummary();
+      setData(res);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const listingData = data.filter((d) => d.path.startsWith('/listing'));
+
+  const listingChart = {
+    labels: listingData.map((d) => d.path),
+    datasets: [
+      {
+        label: t('analytics.views'),
+        data: listingData.map((d) => d.views),
+        backgroundColor: 'rgba(99,102,241,0.5)',
+      },
+    ],
   };
 
-  const handleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const type = e.target.value;
-    setEventType(type);
-    await fetchData(type);
-  };
-
-  const chartData = {
+  const conversionChart = {
     labels: data.map((d) => d.path),
     datasets: [
       {
-        label: t('analytics.events'),
-        data: data.map((d) => d.count),
-        backgroundColor: 'rgba(99,102,241,0.5)',
+        label: t('analytics.conversionRate'),
+        data: data.map((d) => d.conversion_rate),
+        backgroundColor: 'rgba(16,185,129,0.5)',
+      },
+    ],
+  };
+
+  const trafficChart = {
+    labels: data.map((d) => d.path),
+    datasets: [
+      {
+        label: t('analytics.views'),
+        data: data.map((d) => d.views),
+        backgroundColor: 'rgba(239,68,68,0.5)',
       },
     ],
   };
@@ -46,27 +68,16 @@ export default function Analytics({ initialData }: AnalyticsProps) {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold mb-4">{t('analytics.title')}</h1>
-      <label htmlFor="eventType" className="block text-sm font-medium">
-        {t('analytics.filter')}
-      </label>
-      <select
-        id="eventType"
-        value={eventType}
-        onChange={handleChange}
-        className="border p-2 rounded w-full md:w-60"
-      >
-        <option value="page_view">Page Views</option>
-        <option value="click">Clicks</option>
-        <option value="conversion">Conversions</option>
-      </select>
-      <Bar data={chartData} aria-label="analytics chart" role="img" />
+      <Bar data={listingChart} aria-label="listing views chart" role="img" />
+      <Bar data={conversionChart} aria-label="conversion rate chart" role="img" />
+      <Bar data={trafficChart} aria-label="traffic chart" role="img" />
     </div>
   );
 }
 
 export const getServerSideProps: GetServerSideProps<AnalyticsProps> = async () => {
   try {
-    const data = await fetchSummary('page_view');
+    const data = await fetchSummary();
     return { props: { initialData: data } };
   } catch (err) {
     console.error(err);

--- a/client/services/analytics.ts
+++ b/client/services/analytics.ts
@@ -3,9 +3,7 @@ import { SummaryRecord } from '../pages/analytics';
 
 const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
 
-export async function fetchSummary(eventType: string): Promise<SummaryRecord[]> {
-  const res = await axios.get<SummaryRecord[]>(`${api}/analytics/summary`, {
-    params: { event_type: eventType },
-  });
+export async function fetchSummary(): Promise<SummaryRecord[]> {
+  const res = await axios.get<SummaryRecord[]>(`${api}/analytics/summary`);
   return res.data;
 }

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -89,9 +89,19 @@ The analytics module records user interactions and exposes aggregated metrics fo
 - **API** (`services/analytics/api.py`):
   - `POST /analytics/events` – record an event.
   - `GET /analytics/events` – list events by type.
-  - `GET /analytics/summary` – aggregate counts per path.
+  - `GET /analytics/summary` – aggregate counts and conversion rates per path.
 - **Middleware**: `AnalyticsMiddleware` attaches to FastAPI apps and logs `page_view` events asynchronously to keep p95 latency under 300 ms.
 - **Stripe Usage**: conversion events trigger an async usage report to Stripe for billing (skipped when `STRIPE_API_KEY` is absent).
+
+### Architecture Diagram
+```mermaid
+flowchart LR
+    A[Client Request] --> B[AnalyticsMiddleware]
+    B --> C[Analytics API]
+    C --> D[(AnalyticsEvent DB)]
+    D --> E[Summary Endpoint]
+    E --> F[Dashboard Charts]
+```
 
 ### Data Flow
 1. Requests hit any FastAPI service using `AnalyticsMiddleware`.

--- a/services/analytics/api.py
+++ b/services/analytics/api.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from datetime import datetime
 from typing import Dict, Any
 from .service import log_event, list_events, get_summary
+from ..models import EventType
 from .middleware import AnalyticsMiddleware
 
 app = FastAPI()
@@ -10,7 +11,7 @@ app.add_middleware(AnalyticsMiddleware)
 
 
 class EventIn(BaseModel):
-    event_type: str
+    event_type: EventType
     path: str
     user_id: int | None = None
     meta: Dict[str, Any] | None = None
@@ -23,7 +24,10 @@ class EventOut(EventIn):
 
 class SummaryOut(BaseModel):
     path: str
-    count: int
+    views: int
+    clicks: int
+    conversions: int
+    conversion_rate: float
 
 
 @app.post("/analytics/events", response_model=EventOut, status_code=201)
@@ -38,5 +42,5 @@ async def get_events(event_type: str | None = None):
 
 
 @app.get("/analytics/summary", response_model=list[SummaryOut])
-async def summary(event_type: str | None = None):
-    return await get_summary(event_type)
+async def summary():
+    return await get_summary()

--- a/services/analytics/middleware.py
+++ b/services/analytics/middleware.py
@@ -8,5 +8,7 @@ from .service import log_event
 class AnalyticsMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response: Response = await call_next(request)
-        asyncio.create_task(log_event("page_view", request.url.path))
+        # Avoid logging analytics endpoints to prevent recursion
+        if not request.url.path.startswith("/analytics"):
+            asyncio.create_task(log_event("page_view", request.url.path))
         return response

--- a/services/analytics/repository.py
+++ b/services/analytics/repository.py
@@ -1,5 +1,5 @@
 from sqlmodel import select
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, case
 from sqlmodel.ext.asyncio.session import AsyncSession
 from ..models import AnalyticsEvent
 
@@ -18,15 +18,25 @@ def _event_query(event_type: str | None = None):
     return stmt
 
 
-async def fetch_events(session: AsyncSession, event_type: str | None = None) -> list[AnalyticsEvent]:
+async def fetch_events(
+    session: AsyncSession, event_type: str | None = None
+) -> list[AnalyticsEvent]:
     result = await session.exec(_event_query(event_type))
     return result.all()
 
 
-async def aggregate_events(session: AsyncSession, event_type: str | None = None):
-    stmt = select(AnalyticsEvent.path, func.count(AnalyticsEvent.id).label("count"))
-    if event_type:
-        stmt = stmt.where(AnalyticsEvent.event_type == event_type)
-    stmt = stmt.group_by(AnalyticsEvent.path)
+async def aggregate_metrics(session: AsyncSession):
+    stmt = select(
+        AnalyticsEvent.path,
+        func.sum(
+            case((AnalyticsEvent.event_type == "page_view", 1), else_=0)
+        ).label("views"),
+        func.sum(
+            case((AnalyticsEvent.event_type == "click", 1), else_=0)
+        ).label("clicks"),
+        func.sum(
+            case((AnalyticsEvent.event_type == "conversion", 1), else_=0)
+        ).label("conversions"),
+    ).group_by(AnalyticsEvent.path)
     result = await session.exec(stmt)
     return result.all()

--- a/services/models.py
+++ b/services/models.py
@@ -91,11 +91,17 @@ class ABVariant(SQLModel, table=True):
     clicks: int = 0
 
 
+class EventType(str, Enum):
+    page_view = "page_view"
+    click = "click"
+    conversion = "conversion"
+
+
 class AnalyticsEvent(SQLModel, table=True):
     """Stored analytics event for dashboards."""
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    event_type: str
+    event_type: EventType
     path: str
     user_id: Optional[int] = None
     meta: Dict[str, Any] | None = Field(

--- a/status.md
+++ b/status.md
@@ -8,24 +8,22 @@ This file tracks the remaining work required to bring PODPusher to production re
 
 ## Outstanding Tasks
 
-1. **Analytics Enhancements** – Replace mocked analytics with real metrics collected from the database and user interactions.
-2. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
-3. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
-
-4. **Documentation** – Update internal docs and API docs as new features are added.
-5. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-6. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-7. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
-8. Maintain architecture and schema diagrams.
-9. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
-10. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
+1. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
+2. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
+3. **Documentation** – Update internal docs and API docs as new features are added.
+4. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
+5. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+6. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
+7. Maintain architecture and schema diagrams.
+8. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+9. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.
 - Real Integrations – Printify and Etsy clients implemented with stub fallbacks.
 
 - Re-implemented listing composer enhancements (drag-and-drop fields, improved tag suggestions, draft saving, multi-language input).
-
+- Analytics Enhancements – Replace mocked analytics with real metrics collected from the database and user interactions.
 
 ## Instructions to Agents
 


### PR DESCRIPTION
## Summary
- replace mocked analytics with persistent event logging and summary metrics
- add dashboard charts for views, traffic and conversion rates
- document analytics architecture and mark enhancements complete

## Testing
- `flake8 services/analytics services/models.py tests/test_analytics.py`
- `pytest tests/test_analytics.py -q`
- `npm test -- AnalyticsPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68adcc58c3ac832ba1ac4adc4de23ac6