### PR TITLE
feat: add monitoring and observability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,25 +13,35 @@ services:
     command: uvicorn services.trend_scraper.api:app --port 8001 --host 0.0.0.0
     environment:
       - DATABASE_URL=${DATABASE_URL}
+    ports:
+      - "8001:8001"  # metrics at /metrics
   ideation:
     build: .
     command: uvicorn services.ideation.api:app --port 8002 --host 0.0.0.0
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8002:8002"  # metrics at /metrics
   image_gen:
     build: .
     command: uvicorn services.image_gen.api:app --port 8003 --host 0.0.0.0
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8003:8003"  # metrics at /metrics
   integration:
     build: .
     command: uvicorn services.integration.api:app --port 8004 --host 0.0.0.0
     environment:
       - PRINTIFY_API_KEY=${PRINTIFY_API_KEY}
       - ETSY_API_KEY=${ETSY_API_KEY}
+    ports:
+      - "8004:8004"  # metrics at /metrics
   gateway:
     build: .
     command: uvicorn services.gateway.api:app --port 8000 --host 0.0.0.0
+    ports:
+      - "8000:8000"  # metrics at /metrics
   frontend:
     image: node:18
     working_dir: /app
@@ -50,3 +60,9 @@ services:
     depends_on:
       - redis
       - db
+
+# Prometheus scrape job example:
+# scrape_configs:
+#   - job_name: 'podpusher'
+#     static_configs:
+#       - targets: ['gateway:8000', 'trend_scraper:8001', 'ideation:8002', 'image_gen:8003', 'integration:8004']

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -160,3 +160,19 @@ flowchart TD
 ```
 
 During creation, weights are validated to sum to 1. When a click or impression arrives, the service checks the current time against the experiment schedule before incrementing counters. Metrics endpoints combine test and variant data to report conversion rates and weight distribution.
+
+## Monitoring & Observability
+
+All backend services use a shared JSON logging utility defined in
+`services/logging.py`. Logs include `timestamp`, `level`, `module`, `message`,
+and, when available, `request_id` and `user_id`.
+
+Each FastAPI service exposes three endpoints:
+
+- **`/health`** – returns service status, version and database connectivity.
+- **`/ready`** – returns HTTP 200 only when all dependencies are reachable.
+- **`/metrics`** – Prometheus metrics for request counts, latency and error
+  rates.
+
+Middleware automatically records metrics for every request. See
+`docker-compose.yml` for an example Prometheus scrape configuration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ flake8
 black
 aiosqlite
 APScheduler
+prometheus_client

--- a/services/ab_tests/api.py
+++ b/services/ab_tests/api.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from datetime import datetime
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 
 from .service import (
     create_test,
@@ -11,6 +13,8 @@ from .service import (
 from ..models import ExperimentType
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "ab_tests")
 
 
 class VariantCreate(BaseModel):

--- a/services/analytics/api.py
+++ b/services/analytics/api.py
@@ -2,12 +2,16 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from datetime import datetime
 from typing import Dict, Any
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import log_event, list_events, get_summary
 from ..models import EventType
 from .middleware import AnalyticsMiddleware
 
 app = FastAPI()
+_logger = get_logger(__name__)
 app.add_middleware(AnalyticsMiddleware)
+setup_monitoring(app, "analytics")
 
 
 class EventIn(BaseModel):

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from fastapi import FastAPI
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from ..trend_scraper.service import (
     fetch_trends,
     get_trending_categories,
@@ -19,6 +21,7 @@ from ..trend_scraper.events import EVENTS
 from ..analytics.middleware import AnalyticsMiddleware
 
 app = FastAPI()
+_logger = get_logger(__name__)
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
 app.mount("/api/search", search_app)
@@ -26,6 +29,7 @@ app.mount("/ab_tests", ab_app)
 app.mount("/api/ideation", ideation_app)
 app.mount("/api/listing-composer", listing_app)
 app.add_middleware(AnalyticsMiddleware)
+setup_monitoring(app, "gateway")
 
 
 @app.post("/generate")

--- a/services/ideation/api.py
+++ b/services/ideation/api.py
@@ -1,8 +1,12 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_ideas, suggest_tags
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "ideation")
 
 
 class TrendList(BaseModel):

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,10 +1,14 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_images
 from ..common.quotas import quota_middleware
 
 app = FastAPI()
+_logger = get_logger(__name__)
 app.middleware("http")(quota_middleware)
+setup_monitoring(app, "image_gen")
 
 
 class IdeaList(BaseModel):

--- a/services/image_review/api.py
+++ b/services/image_review/api.py
@@ -1,10 +1,13 @@
 from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
-
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import list_products, update_product
 from ..common.localization import get_message
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "image_review")
 
 
 class UpdatePayload(BaseModel):

--- a/services/integration/api.py
+++ b/services/integration/api.py
@@ -1,9 +1,12 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import create_sku, publish_listing
 
-
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "integration")
 
 
 class ProductList(BaseModel):

--- a/services/listing_composer/api.py
+++ b/services/listing_composer/api.py
@@ -1,7 +1,11 @@
 from fastapi import FastAPI, HTTPException
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import DraftPayload, save_draft, get_draft
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "listing_composer")
 
 
 @app.post("/drafts", response_model=DraftPayload)

--- a/services/logging.py
+++ b/services/logging.py
@@ -1,0 +1,78 @@
+import logging
+import json
+import sys
+from datetime import datetime
+import contextvars
+from typing import Optional
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from uuid import uuid4
+
+request_id_ctx = contextvars.ContextVar("request_id", default=None)
+user_id_ctx = contextvars.ContextVar("user_id", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "level": record.levelname,
+            "module": record.name,
+            "message": record.getMessage(),
+        }
+        request_id = getattr(record, "request_id", request_id_ctx.get())
+        user_id = getattr(record, "user_id", user_id_ctx.get())
+        if request_id:
+            log_record["request_id"] = request_id
+        if user_id:
+            log_record["user_id"] = user_id
+        return json.dumps(log_record)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(JsonFormatter())
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+        logger.propagate = True
+    return logger
+
+
+def set_context(
+    request_id: Optional[str] = None, user_id: Optional[str] = None
+) -> None:
+    if request_id is not None:
+        request_id_ctx.set(request_id)
+    if user_id is not None:
+        user_id_ctx.set(user_id)
+
+
+def clear_context() -> None:
+    request_id_ctx.set(None)
+    user_id_ctx.set(None)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, logger: Optional[logging.Logger] = None):
+        super().__init__(app)
+        self.logger = logger or get_logger(__name__)
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = request.headers.get("X-Request-ID", str(uuid4()))
+        user_id = request.headers.get("X-User-Id")
+        set_context(request_id, user_id)
+        self.logger.info(
+            f"{request.method} {request.url.path}",
+            extra={"request_id": request_id, "user_id": user_id},
+        )
+        try:
+            response = await call_next(request)
+            self.logger.info(
+                f"{request.method} {request.url.path} - {response.status_code}",
+                extra={"request_id": request_id, "user_id": user_id},
+            )
+            return response
+        finally:
+            clear_context()

--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -1,0 +1,92 @@
+import os
+import time
+from typing import Awaitable, Callable, Optional
+from fastapi import APIRouter, FastAPI, HTTPException, Response
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from sqlalchemy import text
+from .common.database import get_session
+from .logging import LoggingMiddleware
+
+REQUEST_COUNT = Counter(
+    "request_count", "Total request count", ["service", "method", "path", "status"]
+)
+REQUEST_LATENCY = Histogram(
+    "request_latency_seconds", "Request latency", ["service", "method", "path"]
+)
+REQUEST_ERRORS = Counter(
+    "request_errors_total", "Request errors", ["service", "method", "path", "status"]
+)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, service_name: str):
+        super().__init__(app)
+        self.service_name = service_name
+
+    async def dispatch(self, request: Request, call_next):
+        start = time.time()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception:
+            REQUEST_ERRORS.labels(
+                self.service_name, request.method, request.url.path, str(status_code)
+            ).inc()
+            raise
+        finally:
+            duration = time.time() - start
+            REQUEST_COUNT.labels(
+                self.service_name, request.method, request.url.path, str(status_code)
+            ).inc()
+            REQUEST_LATENCY.labels(
+                self.service_name, request.method, request.url.path
+            ).observe(duration)
+
+
+async def check_db() -> bool:
+    try:
+        async with get_session() as session:
+            await session.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+def setup_monitoring(
+    app: FastAPI,
+    service_name: str,
+    readiness_check: Optional[Callable[[], Awaitable[bool]]] = None,
+) -> None:
+    app.add_middleware(LoggingMiddleware)
+    app.add_middleware(MetricsMiddleware, service_name=service_name)
+
+    router = APIRouter()
+
+    @router.get("/metrics")
+    async def metrics() -> Response:
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    @router.get("/health")
+    async def health() -> dict:
+        db_ok = await check_db()
+        return {
+            "status": "ok" if db_ok else "degraded",
+            "database": db_ok,
+            "version": os.getenv("APP_VERSION", "0.1.0"),
+        }
+
+    @router.get("/ready")
+    async def ready() -> dict:
+        db_ok = await check_db()
+        ext_ok = True
+        if readiness_check:
+            ext_ok = await readiness_check()
+        if db_ok and ext_ok:
+            return {"status": "ready"}
+        raise HTTPException(status_code=503, detail="not ready")
+
+    app.include_router(router)

--- a/services/notifications/api.py
+++ b/services/notifications/api.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 
 from .service import (
     list_notifications,
@@ -9,6 +11,8 @@ from .service import (
 )
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "notifications")
 
 
 @app.on_event("startup")

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import search_products
 
 
@@ -22,6 +23,8 @@ class SearchResponse(BaseModel):
 
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "search")
 
 
 @app.get("/", response_model=SearchResponse)

--- a/services/social_generator/api.py
+++ b/services/social_generator/api.py
@@ -1,9 +1,12 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_post
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "social_generator")
 
 
 class Prompt(BaseModel):

--- a/services/trend_scraper/api.py
+++ b/services/trend_scraper/api.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import (
     fetch_trends,
     get_trending_categories,
@@ -11,6 +13,8 @@ from .events import EVENTS
 from ..tasks import celery_app
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "trend_scraper")
 
 
 @app.on_event("startup")

--- a/services/user/api.py
+++ b/services/user/api.py
@@ -1,11 +1,15 @@
 from datetime import datetime
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from ..common.database import get_session
 from ..models import User
 from ..common.quotas import PLAN_LIMITS
 
 app = FastAPI()
+_logger = get_logger(__name__)
+setup_monitoring(app, "user")
 
 
 @app.get("/api/user/plan")
@@ -34,7 +38,9 @@ class QuotaUpdate(BaseModel):
 
 
 @app.post("/api/user/plan")
-async def increment_quota(data: QuotaUpdate, x_user_id: str = Header(..., alias="X-User-Id")):
+async def increment_quota(
+    data: QuotaUpdate, x_user_id: str = Header(..., alias="X-User-Id")
+):
     async with get_session() as session:
         user = await session.get(User, int(x_user_id))
         if not user:

--- a/status.md
+++ b/status.md
@@ -9,21 +9,21 @@ This file tracks the remaining work required to bring PODPusher to production re
 ## Outstanding Tasks
 
 1. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
-2. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
-3. **Documentation** – Update internal docs and API docs as new features are added.
-4. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-5. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-6. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
-7. Maintain architecture and schema diagrams.
-8. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
-9. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
+2. **Documentation** – Update internal docs and API docs as new features are added.
+3. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
+4. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+5. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
+6. Maintain architecture and schema diagrams.
+7. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+8. **Social Media Generator** – Add a service that produces captions and images for social posts based on product ideas and trends.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.
 - Real Integrations – Printify and Etsy clients implemented with stub fallbacks.
-
 - Re-implemented listing composer enhancements (drag-and-drop fields, improved tag suggestions, draft saving, multi-language input).
 - Analytics Enhancements – Replace mocked analytics with real metrics collected from the database and user interactions.
+
+- Monitoring & Observability – Structured JSON logging, `/health`, `/ready` and `/metrics` endpoints with Prometheus metrics.
 
 ## Instructions to Agents
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,36 @@
+import json
+import logging
+import pytest
+from httpx import AsyncClient, ASGITransport
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db
+from services.logging import JsonFormatter
+
+
+@pytest.mark.asyncio
+async def test_health_ready_metrics_and_logging(caplog):
+    await init_db()
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        resp = await client.get("/ready")
+        assert resp.status_code == 200
+        # trigger metrics
+        await client.get("/health")
+        resp = await client.get("/metrics")
+        assert resp.status_code == 200
+        assert "request_count" in resp.text
+
+    with caplog.at_level(logging.INFO, logger="services.logging"):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.get(
+                "/health",
+                headers={"X-Request-ID": "req-1", "X-User-Id": "42"},
+            )
+    record = next(r for r in reversed(caplog.records) if r.name == "services.logging")
+    data = json.loads(JsonFormatter().format(record))
+    for field in ["timestamp", "level", "module", "message"]:
+        assert field in data
+    assert data["request_id"] == "req-1"
+    assert data["user_id"] == "42"


### PR DESCRIPTION
## Summary
- add shared JSON logger and request context middleware
- expose /health, /ready and /metrics endpoints with Prometheus metrics
- document monitoring features and expose metrics ports in docker compose

## Testing
- `flake8 services/logging.py services/monitoring.py services/ab_tests/api.py services/analytics/api.py services/gateway.api.py services/ideation/api.py services/image_gen/api.py services/image_review/api.py services/integration/api.py services/listing_composer/api.py services/notifications/api.py services/search/api.py services/social_generator/api.py services/trend_scraper/api.py services/user/api.py tests/test_monitoring.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b14fe73cd4832ba4d772a404eb1b7b