### PR TITLE
feat: add bulk product upload via API and UI

### DIFF
--- a/client/components/BulkUploader.tsx
+++ b/client/components/BulkUploader.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { uploadBulk } from '../services/bulk';
+
+interface ResultItem {
+  status: 'ok' | 'error';
+  message: string;
+}
+
+export default function BulkUploader() {
+  const { t } = useTranslation('common');
+  const [uploading, setUploading] = useState(false);
+  const [results, setResults] = useState<ResultItem[]>([]);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setResults([]);
+    try {
+      const data = await uploadBulk(file);
+      const successes = (data.created || []).map((c: any) => ({
+        status: 'ok',
+        message: c.product?.title || c.product?.name || t('bulk.success'),
+      }));
+      const errs = (data.errors || []).map((e: any) => ({
+        status: 'error',
+        message: e.error || 'error',
+      }));
+      setResults([...successes, ...errs]);
+    } catch (err: any) {
+      setResults([{ status: 'error', message: err.message }]);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{t('bulk.title')}</h1>
+      <input type="file" accept=".csv,.json" onChange={handleFile} />
+      {uploading && <p>{t('bulk.uploading')}</p>}
+      <ul className="space-y-1">
+        {results.map((r, i) => (
+          <li key={i} className={r.status === 'ok' ? 'text-green-600' : 'text-red-600'}>
+            {r.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -114,5 +114,12 @@
     "results": "{{count}} results",
     "ratingLabel": "Rating: {{rating}}",
     "noResults": "No results found"
+  },
+  "bulk": {
+    "title": "Bulk Product Upload",
+    "upload": "Upload File",
+    "uploading": "Uploading...",
+    "success": "Created",
+    "error": "Error"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -114,5 +114,12 @@
     "results": "{{count}} resultados",
     "ratingLabel": "Calificación: {{rating}}",
     "noResults": "Sin resultados"
+  },
+  "bulk": {
+    "title": "Carga masiva de productos",
+    "upload": "Subir archivo",
+    "uploading": "Subiendo...",
+    "success": "Creado",
+    "error": "Error"
   }
 }

--- a/client/pages/bulk-upload.tsx
+++ b/client/pages/bulk-upload.tsx
@@ -1,0 +1,9 @@
+import BulkUploader from '../components/BulkUploader';
+
+export default function BulkUploadPage() {
+  return (
+    <div className="space-y-4">
+      <BulkUploader />
+    </div>
+  );
+}

--- a/client/services/bulk.ts
+++ b/client/services/bulk.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+export async function uploadBulk(file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await axios.post(`${api}/api/bulk_create`, form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data as { created: any[]; errors: any[] };
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -15,6 +15,40 @@ flowchart LR
     E --> F[Listing URL]
 ```
 
+## Bulk Product Creation
+
+`POST /api/bulk_create` accepts a CSV or JSON list of product definitions. Each
+item is validated and persisted via the existing Printify integration. The
+response summarises created products and per-item errors.
+
+Sample CSV:
+
+```
+title,description,price,category,variants,image_urls
+"Shirt","Cool shirt",19.99,apparel,"[{""sku"":""s1"",""price"":19.99}]","[""http://example.com/img.png""]"
+```
+
+Sample JSON:
+
+```json
+[
+  {
+    "title": "Shirt",
+    "description": "Cool shirt",
+    "price": 19.99,
+    "category": "apparel",
+    "variants": [{"sku": "s1", "price": 19.99}],
+    "image_urls": ["http://example.com/img.png"]
+  }
+]
+```
+
+Response:
+
+```
+{ "created": [...], "errors": [{ "index": 1, "error": "detail" }] }
+```
+
 ## Social Media Generator Service
 
 The `social_generator` service builds captions and optional images for social

--- a/services/bulk_create/api.py
+++ b/services/bulk_create/api.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import List
+import json
+
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+from .service import (
+    ProductDefinition,
+    parse_products_from_csv,
+    parse_products_from_json,
+    persist_products,
+)
+
+
+class BulkCreateResponse(BaseModel):
+    created: List[dict]
+    errors: List[dict]
+
+
+app = FastAPI()
+
+
+@app.post("", response_model=BulkCreateResponse)
+async def bulk_create(request: Request) -> BulkCreateResponse:
+    content_type = request.headers.get("content-type", "")
+    items: List[ProductDefinition] = []
+    errors: List[dict] = []
+
+    if content_type.startswith("multipart/form-data"):
+        form = await request.form()
+        upload = form.get("file")
+        if upload is None:
+            raise HTTPException(status_code=400, detail="no products provided")
+        content = (await upload.read()).decode("utf-8")
+        filename = getattr(upload, "filename", "")
+        if filename.lower().endswith(".csv"):
+            items, errors = parse_products_from_csv(content)
+        elif filename.lower().endswith(".json"):
+            items, errors = parse_products_from_json(content)
+        else:
+            raise HTTPException(status_code=400, detail="unsupported file type")
+    else:
+        try:
+            products = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="no products provided")
+        items, parse_errors = parse_products_from_json(json.dumps(products))
+        errors.extend(parse_errors)
+
+    created, persist_errors = persist_products(items)
+    errors.extend(persist_errors)
+    return BulkCreateResponse(created=created, errors=errors)

--- a/services/bulk_create/service.py
+++ b/services/bulk_create/service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import List, Tuple
+
+from pydantic import BaseModel, Field, AnyHttpUrl, ValidationError
+
+from ..integration.service import create_sku
+
+
+class Variant(BaseModel):
+    sku: str = Field(..., min_length=1)
+    price: float = Field(..., gt=0)
+
+
+class ProductDefinition(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+    description: str = Field(..., min_length=1)
+    price: float = Field(..., gt=0)
+    category: str = Field(..., min_length=1)
+    variants: List[Variant] = Field(..., min_items=1)
+    image_urls: List[AnyHttpUrl] = Field(default_factory=list)
+
+
+def parse_products_from_csv(data: str) -> Tuple[List[ProductDefinition], List[dict]]:
+    items: List[ProductDefinition] = []
+    errors: List[dict] = []
+    reader = csv.DictReader(io.StringIO(data))
+    for idx, row in enumerate(reader):
+        try:
+            variants = json.loads(row.get("variants", "[]"))
+            images = json.loads(row.get("image_urls", "[]"))
+            product = ProductDefinition(
+                title=row.get("title", ""),
+                description=row.get("description", ""),
+                price=float(row.get("price", 0)),
+                category=row.get("category", ""),
+                variants=variants,
+                image_urls=images,
+            )
+            items.append(product)
+        except (ValidationError, json.JSONDecodeError, ValueError) as exc:
+            errors.append({"index": idx, "error": str(exc)})
+    return items, errors
+
+
+def parse_products_from_json(data: str) -> Tuple[List[ProductDefinition], List[dict]]:
+    items: List[ProductDefinition] = []
+    errors: List[dict] = []
+    try:
+        raw = json.loads(data)
+    except json.JSONDecodeError as exc:
+        return [], [{"index": 0, "error": str(exc)}]
+    for idx, item in enumerate(raw):
+        try:
+            items.append(ProductDefinition(**item))
+        except ValidationError as exc:
+            errors.append({"index": idx, "error": str(exc)})
+    return items, errors
+
+
+def persist_products(products: List[ProductDefinition]) -> Tuple[List[dict], List[dict]]:
+    created: List[dict] = []
+    errors: List[dict] = []
+    for idx, prod in enumerate(products):
+        try:
+            result = create_sku([prod.dict()])[0]
+            created.append({"index": idx, "product": result})
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append({"index": idx, "error": str(exc)})
+    return created, errors

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -16,6 +16,8 @@ from ..search.api import app as search_app
 from ..ab_tests.api import app as ab_app
 from ..listing_composer.api import app as listing_app
 from ..social_generator.api import app as social_app
+from ..bulk_create.api import BulkCreateResponse, bulk_create as bulk_create_handler
+from fastapi import Request
 from ..trend_scraper.events import EVENTS
 from ..analytics.middleware import AnalyticsMiddleware
 
@@ -42,6 +44,11 @@ async def generate():
     listing["listing_url"] = listing.get("etsy_url")
     listing["events"] = events
     return listing
+
+
+@app.post("/api/bulk_create", response_model=BulkCreateResponse)
+async def bulk_create(request: Request):
+    return await bulk_create_handler(request)
 
 
 @app.get("/product-categories")

--- a/status.md
+++ b/status.md
@@ -11,7 +11,6 @@ This file tracks the remaining work required to bring PODPusher to production re
 1. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
 2. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
 3. **Documentation** – Update internal docs and API docs as new features are added.
-4. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
 5. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 6. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 7. Maintain architecture and schema diagrams.
@@ -24,6 +23,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 - Re-implemented listing composer enhancements (drag-and-drop fields, improved tag suggestions, draft saving, multi-language input).
 - Analytics Enhancements – Replace mocked analytics with real metrics collected from the database and user interactions.
 - Social Media Generator – Rule-based captions and images with localisation and dashboard UI.
+- Bulk Product Creation – CSV/JSON bulk upload endpoint and UI implemented.
 
 ## Instructions to Agents
 

--- a/tests/e2e/bulk_uploader.spec.ts
+++ b/tests/e2e/bulk_uploader.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+const csv = 'title,description,price,category,variants,image_urls\nTee,desc,9.99,apparel,"[]","[]"\n';
+
+test('bulk uploader shows results', async ({ page }) => {
+  await page.route('**/api/bulk_create', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        created: [{ index: 0, product: { title: 'Shirt' } }],
+        errors: [],
+      }),
+    });
+  });
+
+  await page.goto('/bulk-upload');
+  await page.setInputFiles('input[type="file"]', {
+    name: 'products.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from(csv),
+  });
+  await expect(page.getByText('Shirt')).toBeVisible();
+});

--- a/tests/test_bulk_api.py
+++ b/tests/test_bulk_api.py
@@ -1,0 +1,58 @@
+import json
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_json_api():
+    await init_db()
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        data = [
+            {
+                "title": "Shirt",
+                "description": "Desc",
+                "price": 9.99,
+                "category": "apparel",
+                "variants": [{"sku": "s1", "price": 9.99}],
+                "image_urls": ["http://example.com/img.png"],
+            },
+            {
+                "title": "",
+                "description": "Bad",
+                "price": -1,
+                "category": "apparel",
+                "variants": [],
+                "image_urls": [],
+            },
+        ]
+        resp = await client.post("/api/bulk_create", json=data)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["created"]) == 1
+        assert len(body["errors"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_csv_api():
+    await init_db()
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        variants = json.dumps([{ "sku": "s1", "price": 9.99 }])
+        images = json.dumps(["http://example.com/img.png"])
+        import io, csv as csvmod
+        out = io.StringIO()
+        writer = csvmod.writer(out)
+        writer.writerow(["title", "description", "price", "category", "variants", "image_urls"])
+        writer.writerow(["Shirt", "Desc", 9.99, "apparel", variants, images])
+        writer.writerow(["", "Bad", 9.99, "apparel", variants, images])
+        csv_content = out.getvalue()
+        files = {"file": ("products.csv", csv_content, "text/csv")}
+        resp = await client.post("/api/bulk_create", files=files)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["created"]) == 1
+        assert len(body["errors"]) == 1

--- a/tests/test_bulk_service.py
+++ b/tests/test_bulk_service.py
@@ -1,0 +1,46 @@
+import json
+from services.bulk_create.service import (
+    parse_products_from_csv,
+    parse_products_from_json,
+)
+
+
+def test_parse_products_from_csv():
+    variants = json.dumps([{ "sku": "s1", "price": 9.99 }])
+    images = json.dumps(["http://example.com/img.png"])
+    import io, csv as csvmod
+
+    output = io.StringIO()
+    writer = csvmod.writer(output)
+    writer.writerow(["title", "description", "price", "category", "variants", "image_urls"])
+    writer.writerow(["Shirt", "Desc", 9.99, "apparel", variants, images])
+    writer.writerow(["", "Bad", 9.99, "apparel", variants, images])
+    csv_content = output.getvalue()
+    items, errors = parse_products_from_csv(csv_content)
+    assert len(items) == 1
+    assert items[0].title == "Shirt"
+    assert len(errors) == 1
+
+
+def test_parse_products_from_json():
+    data = [
+        {
+            "title": "Shirt",
+            "description": "Desc",
+            "price": 9.99,
+            "category": "apparel",
+            "variants": [{"sku": "s1", "price": 9.99}],
+            "image_urls": ["http://example.com/img.png"],
+        },
+        {
+            "title": "",
+            "description": "Bad",
+            "price": -1,
+            "category": "apparel",
+            "variants": [],
+            "image_urls": [],
+        },
+    ]
+    items, errors = parse_products_from_json(json.dumps(data))
+    assert len(items) == 1
+    assert len(errors) == 1


### PR DESCRIPTION
## Summary
- add `ProductDefinition` schema and bulk upload service for CSV/JSON product lists
- expose POST `/api/bulk_create` and React BulkUploader component with translations
- document bulk upload usage and mark status complete

## Testing
- `pytest`
- `npm test --prefix client`
- `npx playwright test` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_68b29bc23960832ba5baf5edb6e18850