### PR TITLE
feat: add monitoring and bulk product creation

### DIFF
--- a/client/__tests__/BulkUploader.test.tsx
+++ b/client/__tests__/BulkUploader.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import BulkUploader from '../components/BulkUploader';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, opts?: any) => key.split('.').pop() })
+}));
+
+jest.mock('../services/bulkUpload', () => ({
+  bulkCreate: jest.fn(() => Promise.resolve({ created: 1, errors: [] }))
+}));
+
+const { bulkCreate } = require('../services/bulkUpload');
+
+test('uploads file and shows success', async () => {
+  render(<BulkUploader />);
+  const file = new File([
+    'title,description,price,category,image_urls\nA,B,10,cat,http://example.com/img.png'
+  ], 'products.csv', { type: 'text/csv' });
+  const input = screen.getByLabelText('upload');
+  fireEvent.change(input, { target: { files: [file] } });
+  fireEvent.click(screen.getByText('upload'));
+  expect(await screen.findByText('success')).toBeInTheDocument();
+  expect(bulkCreate).toHaveBeenCalled();
+});

--- a/client/components/BulkUploader.tsx
+++ b/client/components/BulkUploader.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+import { bulkCreate, BulkResult } from '../services/bulkUpload';
+
+export default function BulkUploader() {
+  const { t } = useTranslation('common');
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<BulkResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upload = async () => {
+    if (!file) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await bulkCreate(file);
+      setResult(res);
+    } catch (e) {
+      setError(t('bulk.error'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{t('bulk.title')}</h1>
+      <input
+        aria-label={t('bulk.upload')}
+        type="file"
+        onChange={(e) => setFile(e.target.files?.[0] || null)}
+      />
+      <button
+        type="button"
+        className="bg-blue-600 text-white px-4 py-2"
+        disabled={!file || loading}
+        onClick={upload}
+      >
+        {t('bulk.upload')}
+      </button>
+      {loading && <p>{t('bulk.progress')}</p>}
+      {result && <p>{t('bulk.success', { count: result.created })}</p>}
+      {error && (
+        <p role="alert" className="text-red-600">
+          {error}
+        </p>
+      )}
+      {result?.errors?.length ? (
+        <ul>
+          {result.errors.map((err, i) => (
+            <li key={i}>{err}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -114,5 +114,12 @@
     "results": "{{count}} results",
     "ratingLabel": "Rating: {{rating}}",
     "noResults": "No results found"
+  },
+  "bulk": {
+    "title": "Bulk Uploader",
+    "upload": "Upload",
+    "progress": "Uploading...",
+    "success": "Created {{count}} products",
+    "error": "Upload failed"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -114,5 +114,12 @@
     "results": "{{count}} resultados",
     "ratingLabel": "Calificación: {{rating}}",
     "noResults": "Sin resultados"
+  },
+  "bulk": {
+    "title": "Carga Masiva",
+    "upload": "Subir",
+    "progress": "Subiendo...",
+    "success": "{{count}} productos creados",
+    "error": "Error al subir"
   }
 }

--- a/client/pages/bulk.tsx
+++ b/client/pages/bulk.tsx
@@ -1,0 +1,5 @@
+import BulkUploader from '../components/BulkUploader';
+
+export default function BulkPage() {
+  return <BulkUploader />;
+}

--- a/client/services/bulkUpload.ts
+++ b/client/services/bulkUpload.ts
@@ -1,0 +1,15 @@
+export interface BulkResult {
+  created: number;
+  errors: string[];
+}
+
+export async function bulkCreate(file: File): Promise<BulkResult> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch('/api/bulk_create', {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) throw new Error('upload_failed');
+  return res.json();
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,25 +13,35 @@ services:
     command: uvicorn services.trend_scraper.api:app --port 8001 --host 0.0.0.0
     environment:
       - DATABASE_URL=${DATABASE_URL}
+    ports:
+      - "8001:8001"
   ideation:
     build: .
     command: uvicorn services.ideation.api:app --port 8002 --host 0.0.0.0
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8002:8002"
   image_gen:
     build: .
     command: uvicorn services.image_gen.api:app --port 8003 --host 0.0.0.0
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+    ports:
+      - "8003:8003"
   integration:
     build: .
     command: uvicorn services.integration.api:app --port 8004 --host 0.0.0.0
     environment:
       - PRINTIFY_API_KEY=${PRINTIFY_API_KEY}
       - ETSY_API_KEY=${ETSY_API_KEY}
+    ports:
+      - "8004:8004"
   gateway:
     build: .
     command: uvicorn services.gateway.api:app --port 8000 --host 0.0.0.0
+    ports:
+      - "8000:8000"
   frontend:
     image: node:18
     working_dir: /app

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -161,3 +161,40 @@ flowchart TD
 ```
 
 During creation, weights are validated to sum to 1. When a click or impression arrives, the service checks the current time against the experiment schedule before incrementing counters. Metrics endpoints combine test and variant data to report conversion rates and weight distribution.
+
+## Monitoring and Observability
+
+All FastAPI services share a common monitoring setup provided by `services.monitoring.setup_monitoring`. It registers middleware that records request counts, latencies and errors using `prometheus_client` counters and histograms. Each request receives a correlation ID exposed via the `X-Request-ID` header and propagated to JSON logs via `services.logging.get_logger`.
+
+Three endpoints are available on every service:
+
+- `GET /health` – basic liveness check.
+- `GET /ready` – readiness probe.
+- `GET /metrics` – Prometheus metrics scrape endpoint.
+
+## Bulk Product Creation
+
+The gateway exposes `POST /api/bulk_create` to ingest multiple products in one request. Payloads may be JSON or CSV files. Each item is validated against the `ProductDefinition` schema (title, description, price, category, variants and image URLs). Valid products are persisted via existing SKU creation logic and the response summarises creations and validation errors.
+
+### Sample JSON
+
+```json
+{
+  "products": [
+    {
+      "title": "Mug",
+      "description": "Ceramic mug",
+      "price": 9.99,
+      "category": "drinkware",
+      "image_urls": ["https://example.com/mug.png"]
+    }
+  ]
+}
+```
+
+### Sample CSV
+
+```
+title,description,price,category,image_urls
+Mug,Ceramic mug,9.99,drinkware,https://example.com/mug.png
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ black
 aiosqlite
 APScheduler
 Pillow
+prometheus_client
+python-multipart

--- a/services/ab_tests/api.py
+++ b/services/ab_tests/api.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from datetime import datetime
 
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import (
     create_test,
     get_metrics,
@@ -11,6 +13,8 @@ from .service import (
 from ..models import ExperimentType
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 class VariantCreate(BaseModel):

--- a/services/analytics/api.py
+++ b/services/analytics/api.py
@@ -1,12 +1,17 @@
 from fastapi import FastAPI
+from fastapi import FastAPI
 from pydantic import BaseModel
 from datetime import datetime
 from typing import Dict, Any
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import log_event, list_events, get_summary
 from ..models import EventType
 from .middleware import AnalyticsMiddleware
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 app.add_middleware(AnalyticsMiddleware)
 
 

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -1,5 +1,12 @@
 from datetime import datetime
-from fastapi import FastAPI
+import csv
+import json
+from typing import Dict, List, Optional
+from fastapi import FastAPI, UploadFile, File, HTTPException, Request
+from pydantic import BaseModel, HttpUrl, ValidationError, Field
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from ..trend_scraper.service import (
     fetch_trends,
     get_trending_categories,
@@ -20,6 +27,8 @@ from ..trend_scraper.events import EVENTS
 from ..analytics.middleware import AnalyticsMiddleware
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 app.mount("/api/images/review", review_app)
 app.mount("/api/notifications", notifications_app)
 app.mount("/api/search", search_app)
@@ -28,6 +37,62 @@ app.mount("/api/ideation", ideation_app)
 app.mount("/api/listing-composer", listing_app)
 app.mount("/api/social", social_app)
 app.add_middleware(AnalyticsMiddleware)
+
+
+class Variant(BaseModel):
+    sku: Optional[str] = None
+    price: float = Field(..., gt=0)
+    options: Dict[str, str] | None = None
+
+
+class ProductDefinition(BaseModel):
+    title: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    price: float = Field(..., gt=0)
+    category: str = Field(..., min_length=1)
+    variants: List[Variant] = []
+    image_urls: List[HttpUrl] = []
+
+
+class BulkResult(BaseModel):
+    created: int
+    errors: List[str]
+
+
+@app.post("/api/bulk_create", response_model=BulkResult)
+async def bulk_create(request: Request, file: UploadFile | None = File(None)):
+    items: List[Dict] = []
+    if request.headers.get("content-type", "").startswith("application/json"):
+        body = await request.json()
+        items = body.get("products", [])
+    elif file is not None:
+        content = await file.read()
+        try:
+            if file.filename.endswith(".json"):
+                items = json.loads(content)
+            else:
+                reader = csv.DictReader(content.decode().splitlines())
+                for row in reader:
+                    if row.get("image_urls"):
+                        row["image_urls"] = [u.strip() for u in row["image_urls"].split(",") if u.strip()]
+                    items.append(row)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid file")
+    else:
+        raise HTTPException(status_code=400, detail="No input provided")
+
+    created = 0
+    errors: List[str] = []
+    for idx, item in enumerate(items):
+        try:
+            prod = ProductDefinition(**item)
+            create_sku([prod.dict()])
+            created += 1
+        except ValidationError as exc:
+            errors.append(f"{idx}: {exc.errors()}")
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            errors.append(f"{idx}: {str(exc)}")
+    return {"created": created, "errors": errors}
 
 
 @app.post("/generate")

--- a/services/ideation/api.py
+++ b/services/ideation/api.py
@@ -1,8 +1,14 @@
 from fastapi import FastAPI
+from fastapi import FastAPI
 from pydantic import BaseModel
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_ideas, suggest_tags
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 class TrendList(BaseModel):

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,9 +1,14 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_images
 from ..common.quotas import quota_middleware
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 app.middleware("http")(quota_middleware)
 
 

--- a/services/image_review/api.py
+++ b/services/image_review/api.py
@@ -1,10 +1,14 @@
 from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel
 
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import list_products, update_product
 from ..common.localization import get_message
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 class UpdatePayload(BaseModel):

--- a/services/integration/api.py
+++ b/services/integration/api.py
@@ -1,9 +1,15 @@
 from fastapi import FastAPI
+from fastapi import FastAPI
 from pydantic import BaseModel
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import create_sku, publish_listing
 
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 class ProductList(BaseModel):

--- a/services/listing_composer/api.py
+++ b/services/listing_composer/api.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI, HTTPException
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import DraftPayload, save_draft, get_draft
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 @app.post("/drafts", response_model=DraftPayload)

--- a/services/logging.py
+++ b/services/logging.py
@@ -1,0 +1,34 @@
+import json
+import logging
+from contextvars import ContextVar
+from typing import Optional
+
+request_id_ctx: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    """Format logs as structured JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple formatting
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        request_id = request_id_ctx.get()
+        if request_id:
+            log_record["correlation_id"] = request_id
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger configured for JSON output."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/services/monitoring.py
+++ b/services/monitoring.py
@@ -1,0 +1,50 @@
+import time
+import uuid
+from fastapi import FastAPI, Request, Response
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+from .logging import request_id_ctx
+
+REQUEST_COUNT = Counter(
+    "http_requests_total", "Total HTTP requests", ["method", "path", "status"]
+)
+REQUEST_LATENCY = Histogram(
+    "http_request_latency_seconds", "Request latency", ["method", "path"]
+)
+REQUEST_ERRORS = Counter(
+    "http_request_errors_total", "Request errors", ["method", "path", "status"]
+)
+
+
+def setup_monitoring(app: FastAPI) -> None:
+    """Attach monitoring middleware and endpoints to the app."""
+
+    @app.middleware("http")
+    async def metrics_middleware(request: Request, call_next):
+        request_id_ctx.set(str(uuid.uuid4()))
+        start = time.time()
+        try:
+            response: Response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - simple error path
+            duration = time.time() - start
+            status = getattr(exc, "status_code", 500)
+            REQUEST_LATENCY.labels(request.method, request.url.path).observe(duration)
+            REQUEST_COUNT.labels(request.method, request.url.path, status).inc()
+            REQUEST_ERRORS.labels(request.method, request.url.path, status).inc()
+            raise
+        duration = time.time() - start
+        REQUEST_LATENCY.labels(request.method, request.url.path).observe(duration)
+        REQUEST_COUNT.labels(request.method, request.url.path, response.status_code).inc()
+        response.headers["X-Request-ID"] = request_id_ctx.get() or ""
+        return response
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/ready")
+    async def ready():
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    async def metrics():
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/services/notifications/api.py
+++ b/services/notifications/api.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import (
     list_notifications,
     create_notification,
@@ -9,6 +11,8 @@ from .service import (
 )
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 @app.on_event("startup")

--- a/services/search/api.py
+++ b/services/search/api.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI
+from fastapi import FastAPI
 from pydantic import BaseModel
 
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import search_products
 
 
@@ -22,6 +25,8 @@ class SearchResponse(BaseModel):
 
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 @app.get("/", response_model=SearchResponse)

--- a/services/social_generator/api.py
+++ b/services/social_generator/api.py
@@ -2,9 +2,13 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
 
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import generate_post
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 class SocialRequest(BaseModel):

--- a/services/trend_scraper/api.py
+++ b/services/trend_scraper/api.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from .service import (
     fetch_trends,
     get_trending_categories,
@@ -11,6 +14,8 @@ from .events import EVENTS
 from ..tasks import celery_app
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 @app.on_event("startup")

--- a/services/user/api.py
+++ b/services/user/api.py
@@ -1,11 +1,16 @@
 from datetime import datetime
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+
+from ..logging import get_logger
+from ..monitoring import setup_monitoring
 from ..common.database import get_session
 from ..models import User
 from ..common.quotas import PLAN_LIMITS
 
 app = FastAPI()
+logger = get_logger(__name__)
+setup_monitoring(app)
 
 
 @app.get("/api/user/plan")

--- a/status.md
+++ b/status.md
@@ -9,13 +9,11 @@ This file tracks the remaining work required to bring PODPusher to production re
 ## Outstanding Tasks
 
 1. **Testing & QA** – Increase unit, integration and end-to-end test coverage. Ensure Playwright tests run reliably in CI.
-2. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
-3. **Documentation** – Update internal docs and API docs as new features are added.
-4. **Bulk Product Creation** – Add a CSV/bulk upload endpoint (`/api/bulk_create`) and UI for uploading multiple products, including progress indicators and error handling.
-5. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-6. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
-7. Maintain architecture and schema diagrams.
-8. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+2. **Documentation** – Update internal docs and API docs as new features are added.
+3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
+5. Maintain architecture and schema diagrams.
+6. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.
@@ -24,6 +22,8 @@ This file tracks the remaining work required to bring PODPusher to production re
 - Re-implemented listing composer enhancements (drag-and-drop fields, improved tag suggestions, draft saving, multi-language input).
 - Analytics Enhancements – Replace mocked analytics with real metrics collected from the database and user interactions.
 - Social Media Generator – Rule-based captions and images with localisation and dashboard UI.
+- Monitoring & Observability – Structured JSON logging with correlation IDs, health/ready/metrics endpoints and Prometheus instrumentation.
+- Bulk Product Creation – CSV/JSON upload endpoint and responsive dashboard UI for multi-product creation.
 
 ## Instructions to Agents
 

--- a/tests/e2e/bulk_upload.spec.ts
+++ b/tests/e2e/bulk_upload.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('bulk uploader page renders', async ({ page }) => {
+  await page.goto('/bulk');
+  await expect(page.getByText('Bulk Uploader')).toBeVisible();
+});

--- a/tests/test_bulk_create.py
+++ b/tests/test_bulk_create.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+from services.gateway.api import app
+
+client = TestClient(app)
+
+
+def sample_products():
+    return [
+        {
+            "title": "Test",
+            "description": "Desc",
+            "price": 9.99,
+            "category": "shirts",
+            "variants": [],
+            "image_urls": ["http://example.com/img.png"],
+        }
+    ]
+
+
+def test_bulk_create_json():
+    resp = client.post("/api/bulk_create", json={"products": sample_products()})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["created"] == 1
+    assert data["errors"] == []
+
+
+def test_bulk_create_csv():
+    csv_content = "title,description,price,category,image_urls\nA,B,10,cat,http://example.com/img.png"
+    files = {"file": ("products.csv", csv_content, "text/csv")}
+    resp = client.post("/api/bulk_create", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["created"] == 1
+
+
+def test_bulk_create_invalid():
+    bad = [{"title": "", "description": "", "price": -1, "category": ""}]
+    resp = client.post("/api/bulk_create", json={"products": bad})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["created"] == 0
+    assert data["errors"]

--- a/tests/test_health_ready_metrics.py
+++ b/tests/test_health_ready_metrics.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from services.gateway.api import app
+
+def test_health_ready_endpoints():
+    client = TestClient(app)
+    assert client.get("/health").json() == {"status": "ok"}
+    assert client.get("/ready").json() == {"status": "ok"}
+
+
+def test_metrics_increment():
+    client = TestClient(app)
+    client.get("/health")
+    metrics = client.get("/metrics").text
+    assert "http_requests_total" in metrics


### PR DESCRIPTION
## Summary
- implement centralized JSON logging with correlation IDs
- add monitoring middleware with /health, /ready and /metrics endpoints and integrate across services
- introduce bulk product creation API, React BulkUploader UI and related tests

## Testing
- `pytest`
- `npm test`
- `npx playwright test` *(fails: required interactive install of playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68b29b9cb6e4832b9be9690ba4301ec4