### PR TITLE
docs: expand internal documentation and status

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,160 @@
+openapi: 3.1.0
+info:
+  title: FastAPI
+  version: 0.1.0
+paths:
+  /generate:
+    post:
+      summary: Generate
+      operationId: generate_generate_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+  /api/bulk_create:
+    post:
+      summary: Bulk Create
+      operationId: bulk_create_api_bulk_create_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkCreateResponse'
+  /product-categories:
+    get:
+      summary: Product Categories
+      operationId: product_categories_product_categories_get
+      parameters:
+      - name: category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Category
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /design-ideas:
+    get:
+      summary: Design Ideas
+      operationId: design_ideas_design_ideas_get
+      parameters:
+      - name: category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Category
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /product-suggestions:
+    get:
+      summary: Product Suggestions
+      operationId: product_suggestions_product_suggestions_get
+      parameters:
+      - name: category
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Category
+      - name: design
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Design
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    BulkCreateResponse:
+      properties:
+        created:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Created
+        errors:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Errors
+      type: object
+      required:
+      - created
+      - errors
+      title: BulkCreateResponse
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError

--- a/status.md
+++ b/status.md
@@ -9,21 +9,21 @@ This file tracks the remaining work required to bring PODPusher to production re
 ## Outstanding Tasks
 
 1. **Monitoring & Observability** – Add structured logging, health checks and metrics for each service.
-2. **Documentation** – Update internal docs and API docs as new features are added.
-3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
-4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
-5. Maintain architecture and schema diagrams.
-6. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
+2. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
+3. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
+4. Maintain architecture and schema diagrams.
+5. **Stub Removal** – Once integrations and features are fully implemented and tested, remove any placeholder or stubbed logic from the codebase.
 
 ## Completed
+
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.
 - Real Integrations – Printify and Etsy clients implemented with stub fallbacks.
-
 - Re-implemented listing composer enhancements (drag-and-drop fields, improved tag suggestions, draft saving, multi-language input).
 - Analytics Enhancements – Replace mocked analytics with real metrics collected from the database and user interactions.
 - Social Media Generator – Rule-based captions and images with localisation and dashboard UI.
 - Bulk Product Creation – CSV/JSON bulk upload endpoint and UI implemented.
 - Testing & QA – Expanded unit, integration and Playwright end-to-end test coverage with CI integration.
+- Documentation – Internal docs and API docs updated with latest features.
 
 ## Instructions to Agents
 


### PR DESCRIPTION
## Summary
- Document advanced search, A/B testing v3, analytics, listing composer, social generator, bulk creation, real integrations, notifications, monitoring, and localization in `internal_docs.md`
- Add architecture diagram, API reference, feature overview, and agent responsibility links
- Generate `openapi.yaml` and mark documentation task as complete in `status.md`

## Testing
- `npx markdownlint-cli@0.45.0 --disable MD013 MD012 -- docs/internal_docs.md status.md`


------
https://chatgpt.com/codex/tasks/task_e_68bb9e0d9a48832bb2d8ecead5bac723