### PR TITLE
feat(trend): add live trend ingestion service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ PRINTIFY_API_KEY=
 ETSY_API_KEY=
 DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/pod
 REDIS_URL=redis://redis:6379/0
+PLAYWRIGHT_PROXY=
+SCRAPE_INTERVAL_HOURS=6

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -110,6 +110,23 @@ flowchart LR
     E --> F
 ```
 
+## Trend Ingestion Service
+
+The `trend_ingestion` service scrapes public trending pages, normalises text and
+stores the highest scoring signals for the API.
+
+```mermaid
+flowchart LR
+    A[Playwright Scrapers] --> B[Normalisation]
+    B --> C[(PostgreSQL)]
+    C --> D[Gateway /api/trends/live]
+```
+
+Environment variables:
+
+- `PLAYWRIGHT_PROXY` – optional proxy passed to Playwright.
+- `SCRAPE_INTERVAL_HOURS` – schedule interval for automatic scraping.
+
 ## Frontend Page
 
 The `/social-generator` page lets sellers enter product details and preview the

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ black
 aiosqlite
 APScheduler
 Pillow
+playwright

--- a/services/models.py
+++ b/services/models.py
@@ -13,6 +13,15 @@ class Trend(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class TrendSignal(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    source: str
+    keyword: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)
+    engagement_score: int = 0
+    category: str = "other"
+
+
 class Idea(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     trend_id: int

--- a/services/trend_ingestion/api.py
+++ b/services/trend_ingestion/api.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+
+from .service import get_live_trends, refresh_trends, start_scheduler
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    start_scheduler()
+
+
+@app.get("/trends/live")
+async def live_trends(category: str | None = None):
+    return await get_live_trends(category)
+
+
+@app.post("/trends/refresh")
+async def refresh_endpoint():
+    await refresh_trends()
+    return {"status": "ok"}

--- a/services/trend_ingestion/service.py
+++ b/services/trend_ingestion/service.py
@@ -1,0 +1,201 @@
+import asyncio
+import os
+import random
+import re
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, List
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from playwright.async_api import async_playwright
+from sqlmodel import select
+
+from ..common.database import get_session
+from ..models import TrendSignal
+
+USER_AGENTS = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/118.0",
+]
+
+STOPWORDS = {"the", "and", "a", "of", "to", "in"}
+EMOJI_RE = re.compile(r"[\U00010000-\U0010ffff]", flags=re.UNICODE)
+
+SCRAPE_INTERVAL_HOURS = int(os.getenv("SCRAPE_INTERVAL_HOURS", "6"))
+PLAYWRIGHT_PROXY = os.getenv("PLAYWRIGHT_PROXY")
+TOP_K = 5
+
+scheduler = AsyncIOScheduler()
+
+
+def normalize_text(text: str) -> str:
+    """Lowercase text, remove emojis and stopwords."""
+    text = EMOJI_RE.sub("", text).lower()
+    words = [w for w in re.split(r"\W+", text) if w and w not in STOPWORDS]
+    return " ".join(words)
+
+
+def compute_engagement(likes: int, shares: int, comments: int) -> int:
+    return likes + shares + comments
+
+
+CATEGORIES: Dict[str, List[str]] = {
+    "animals": ["cat", "dog", "pet", "animal"],
+    "activism": ["protest", "climate", "justice", "rights"],
+    "sports": ["game", "soccer", "basketball", "tennis"],
+}
+
+
+def categorize(keyword: str) -> str:
+    for category, keys in CATEGORIES.items():
+        if any(k in keyword for k in keys):
+            return category
+    return "other"
+
+
+async def _scrape_source(playwright, source: str, url: str, selectors: Dict[str, str]) -> List[Dict[str, Any]]:
+    ua = random.choice(USER_AGENTS)
+    proxy = {"server": PLAYWRIGHT_PROXY} if PLAYWRIGHT_PROXY else None
+    browser = await playwright.chromium.launch(headless=True, proxy=proxy)
+    context = await browser.new_context(user_agent=ua)
+    page = await context.new_page()
+    await page.goto(url)
+    items = await page.query_selector_all(selectors["item"])
+    results: List[Dict[str, Any]] = []
+    for item in items[:TOP_K]:
+        title_el = await item.query_selector(selectors["title"])
+        hashtag_el = await item.query_selector(selectors["hashtags"])
+        likes_el = await item.query_selector(selectors["likes"])
+        shares_el = await item.query_selector(selectors["shares"])
+        comments_el = await item.query_selector(selectors["comments"])
+        if not title_el:
+            continue
+        title = await title_el.inner_text()
+        hashtags = await hashtag_el.inner_text() if hashtag_el else ""
+        likes = int((await likes_el.inner_text()) or 0) if likes_el else 0
+        shares = int((await shares_el.inner_text()) or 0) if shares_el else 0
+        comments = int((await comments_el.inner_text()) or 0) if comments_el else 0
+        keyword = normalize_text(f"{title} {hashtags}")
+        engagement = compute_engagement(likes, shares, comments)
+        results.append(
+            {
+                "source": source,
+                "keyword": keyword,
+                "engagement_score": engagement,
+                "category": categorize(keyword),
+            }
+        )
+    await browser.close()
+    return results
+
+
+PLATFORM_CONFIG = {
+    "tiktok": {
+        "url": "https://www.tiktok.com/foryou",
+        "selectors": {
+            "item": "div.item",
+            "title": ".title",
+            "hashtags": ".hashtags",
+            "likes": ".likes",
+            "shares": ".shares",
+            "comments": ".comments",
+        },
+    },
+    "instagram": {
+        "url": "https://www.instagram.com/explore",
+        "selectors": {
+            "item": "div.item",
+            "title": ".title",
+            "hashtags": ".hashtags",
+            "likes": ".likes",
+            "shares": ".shares",
+            "comments": ".comments",
+        },
+    },
+    "twitter": {
+        "url": "https://twitter.com/explore",
+        "selectors": {
+            "item": "div.item",
+            "title": ".title",
+            "hashtags": ".hashtags",
+            "likes": ".likes",
+            "shares": ".shares",
+            "comments": ".comments",
+        },
+    },
+    "etsy": {
+        "url": "https://www.etsy.com/trending-items",
+        "selectors": {
+            "item": "div.item",
+            "title": ".title",
+            "hashtags": ".hashtags",
+            "likes": ".likes",
+            "shares": ".shares",
+            "comments": ".comments",
+        },
+    },
+}
+
+
+async def refresh_trends() -> None:
+    """Scrape all platforms and persist top signals."""
+    async with async_playwright() as pw:
+        tasks = [
+            _scrape_source(pw, name, cfg["url"], cfg["selectors"])
+            for name, cfg in PLATFORM_CONFIG.items()
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    signals: List[Dict[str, Any]] = []
+    for res in results:
+        if isinstance(res, list):
+            signals.extend(res)
+
+    if not signals:
+        return
+
+    async with get_session() as session:
+        for source in {s["source"] for s in signals}:
+            top = sorted(
+                [s for s in signals if s["source"] == source],
+                key=lambda s: s["engagement_score"],
+                reverse=True,
+            )[:TOP_K]
+            for sig in top:
+                ts = TrendSignal(
+                    source=sig["source"],
+                    keyword=sig["keyword"],
+                    engagement_score=sig["engagement_score"],
+                    category=sig["category"],
+                    timestamp=datetime.utcnow(),
+                )
+                session.add(ts)
+        await session.commit()
+
+
+async def get_live_trends(category: str | None = None) -> Dict[str, List[Dict[str, Any]]]:
+    async with get_session() as session:
+        stmt = select(TrendSignal)
+        if category:
+            stmt = stmt.where(TrendSignal.category == category)
+        result = await session.exec(stmt)
+        rows = result.all()
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[row.category].append(
+            {
+                "source": row.source,
+                "keyword": row.keyword,
+                "engagement_score": row.engagement_score,
+                "timestamp": row.timestamp.isoformat(),
+            }
+        )
+    return grouped
+
+
+def start_scheduler() -> None:
+    if scheduler.running:
+        return
+    scheduler.add_job(refresh_trends, "interval", hours=SCRAPE_INTERVAL_HOURS)
+    scheduler.start()

--- a/status.md
+++ b/status.md
@@ -13,6 +13,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 5. Maintain architecture and schema diagrams.
+6. **Live Trend Signals Ingestion** – Build Playwright scrapers and storage per Data‑Seeder responsibilities in `agents.md`.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.

--- a/tests/e2e/fixtures/mock_trend.html
+++ b/tests/e2e/fixtures/mock_trend.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+  <div class="item">
+    <div class="title">Funny Cats</div>
+    <div class="hashtags">#cats #funny</div>
+    <div class="likes">10</div>
+    <div class="shares">2</div>
+    <div class="comments">1</div>
+  </div>
+</body>
+</html>

--- a/tests/e2e/trend_ingestion.spec.ts
+++ b/tests/e2e/trend_ingestion.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const file = path.join(__dirname, 'fixtures', 'mock_trend.html');
+
+test('mock trend page selectors', async ({ page }) => {
+  await page.goto('file://' + file);
+  const items = await page.$$('div.item');
+  expect(items.length).toBeGreaterThan(0);
+  const title = await items[0].$('.title');
+  await expect(title).not.toBeNull();
+  expect(await title?.textContent()).toBe('Funny Cats');
+  const likes = await items[0].$('.likes');
+  expect(await likes?.textContent()).toBe('10');
+});

--- a/tests/test_trend_ingestion_api.py
+++ b/tests/test_trend_ingestion_api.py
@@ -1,0 +1,60 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from services.gateway.api import app as gateway_app
+from services.common.database import init_db, get_session
+from services.models import TrendSignal
+
+
+@pytest.mark.asyncio
+async def test_live_trends_endpoint():
+    await init_db()
+    async with get_session() as session:
+        session.add(
+            TrendSignal(source="tiktok", keyword="funny cat", engagement_score=5, category="animals")
+        )
+        session.add(
+            TrendSignal(source="twitter", keyword="climate", engagement_score=3, category="activism")
+        )
+        await session.commit()
+
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/trends/live")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "animals" in data
+        assert data["animals"][0]["keyword"] == "funny cat"
+
+        resp = await client.get("/api/trends/live", params={"category": "activism"})
+        assert resp.status_code == 200
+        filtered = resp.json()
+        assert list(filtered.keys()) == ["activism"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_endpoint(monkeypatch):
+    await init_db()
+
+    async def fake_refresh():
+        async with get_session() as session:
+            session.add(
+                TrendSignal(
+                    source="etsy",
+                    keyword="handmade",
+                    engagement_score=1,
+                    category="other",
+                )
+            )
+            await session.commit()
+
+    monkeypatch.setattr("services.gateway.api.refresh_trends", fake_refresh)
+
+    transport = ASGITransport(app=gateway_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/trends/refresh")
+        assert resp.status_code == 200
+
+        resp = await client.get("/api/trends/live")
+        data = resp.json()
+        assert "other" in data

--- a/tests/test_trend_ingestion_utils.py
+++ b/tests/test_trend_ingestion_utils.py
@@ -1,0 +1,15 @@
+from services.trend_ingestion.service import normalize_text, compute_engagement, categorize
+
+
+def test_normalize_text_removes_emojis_and_stopwords():
+    text = "The 🐶 Dog and THE Cat"
+    assert normalize_text(text) == "dog cat"
+
+
+def test_compute_engagement_sum():
+    assert compute_engagement(1, 2, 3) == 6
+
+
+def test_categorize_keyword():
+    assert categorize("funny cat video") == "animals"
+    assert categorize("unknown term") == "other"


### PR DESCRIPTION
## Summary
- add `trend_ingestion` microservice using Playwright to scrape multiple platforms and persist TrendSignal records
- expose `/api/trends/live` and `/api/trends/refresh` routes in gateway with APScheduler refresh
- document trend ingestion flow and new env vars

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `npx -y playwright test tests/e2e/trend_ingestion.spec.ts --browser=chromium` *(fails: npm error canceled)*
- `flake8` *(fails: style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68be841e69a8832bb733cd3d91869082