### PR TITLE
feat: add configurable image generation service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=
+GEMINI_API_KEY=
+PROVIDER=openai
 PRINTIFY_API_KEY=
 ETSY_API_KEY=
 DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/pod

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -28,6 +28,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/generate" className="hover:underline">{t('nav.generate')}</Link>
           <Link href="/categories" className="hover:underline">{t('nav.categories')}</Link>
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
+          <Link href="/images" className="hover:underline">{t('nav.images')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -4,6 +4,7 @@
     "generate": "Generate",
     "categories": "Categories",
     "designIdeas": "Design Ideas",
+    "images": "Images",
     "suggestions": "Suggestions",
     "search": "Search",
     "analytics": "Analytics",
@@ -44,6 +45,15 @@
     "stars_other": "{{count}} Stars",
     "tags": "Tags",
     "flag": "Flag as inappropriate"
+  },
+  "images": {
+    "title": "Images",
+    "ideaId": "Idea ID",
+    "style": "Style",
+    "generate": "Generate",
+    "delete": "Delete",
+    "regenerate": "Regenerate",
+    "select": "Select"
   },
   "listings": {
     "pageTitle": "Listing Composer",

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -4,6 +4,7 @@
     "generate": "Generar",
     "categories": "Categorías",
     "designIdeas": "Ideas de diseño",
+    "images": "Imágenes",
     "suggestions": "Sugerencias",
     "search": "Buscar",
     "analytics": "Analíticas",
@@ -44,6 +45,15 @@
     "stars_other": "{{count}} estrellas",
     "tags": "Etiquetas",
     "flag": "Marcar como inapropiado"
+  },
+  "images": {
+    "title": "Imágenes",
+    "ideaId": "ID de Idea",
+    "style": "Estilo",
+    "generate": "Generar",
+    "delete": "Eliminar",
+    "regenerate": "Regenerar",
+    "select": "Seleccionar"
   },
   "listings": {
     "pageTitle": "Compositor de publicaciones",

--- a/client/pages/images/index.tsx
+++ b/client/pages/images/index.tsx
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+interface Img {
+  id: number | null;
+  url: string;
+  provider?: string;
+}
+
+export default function ImagesPage() {
+  const { t } = useTranslation('common');
+  const [ideaId, setIdeaId] = useState('');
+  const [style, setStyle] = useState('');
+  const [images, setImages] = useState<Img[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    if (ideaId) {
+      axios
+        .get<Img[]>(`${api}/api/images/${ideaId}`)
+        .then((res) => setImages(res.data))
+        .catch(() => {});
+    }
+  }, [api, ideaId]);
+
+  const generate = async () => {
+    try {
+      const res = await axios.post<Img[]>(`${api}/api/images/generate`, {
+        idea_id: Number(ideaId),
+        style,
+      });
+      setImages(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const remove = async (id: number) => {
+    try {
+      await axios.delete(`${api}/api/images/${id}`);
+      setImages((imgs) => imgs.filter((i) => i.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{t('images.title')}</h1>
+      <div className="flex gap-2">
+        <input
+          className="border p-2"
+          placeholder={t('images.ideaId')}
+          value={ideaId}
+          onChange={(e) => setIdeaId(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder={t('images.style')}
+          value={style}
+          onChange={(e) => setStyle(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={generate}
+          className="bg-blue-600 text-white px-4 py-2"
+        >
+          {t('images.generate')}
+        </button>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {images.map((img) => (
+          <div
+            key={img.id ?? img.url}
+            className={`border p-2 space-y-2 ${
+              selected === img.id ? 'ring-2 ring-blue-500' : ''
+            }`}
+          >
+            <img src={img.url} alt="generated" className="w-full h-auto" />
+            <div className="flex gap-2 text-sm">
+              <button
+                type="button"
+                onClick={() => setSelected(img.id ?? 0)}
+                className="text-blue-600"
+              >
+                {t('images.select')}
+              </button>
+              {img.id && (
+                <button
+                  type="button"
+                  onClick={() => remove(img.id!)}
+                  className="text-red-600"
+                >
+                  {t('images.delete')}
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -117,6 +117,31 @@ generated caption and image. The caption can be edited, copied to the clipboard
 and the image downloaded. The feature honours the user's auto-generation and
 social handle preferences.
 
+## High-Resolution Image Generation Service
+
+The image generation microservice can render product mock-ups using either
+OpenAI's `gpt-image-1` model or Google's Gemini API. The default provider is
+selected with the `PROVIDER` environment variable and may be overridden per
+request via a `provider_override` field.
+
+### Environment Variables
+
+- `PROVIDER` – default provider (`openai` or `gemini`)
+- `OPENAI_API_KEY` – credential for OpenAI
+- `GEMINI_API_KEY` – credential for Gemini
+
+### API
+
+- **POST `/api/images/generate`** – body `{ idea_id, style, provider_override? }`
+  returns a list of `{ id, url }` objects. Images are saved to S3 when
+  configured or to `/data/images` otherwise.
+- **GET `/api/images/{idea_id}`** – list stored images for an idea.
+- **DELETE `/api/images/{image_id}`** – remove an image.
+
+If generation fails, the service responds with a placeholder image URL. The
+dashboard exposes an **Images** tab to view, select, delete or regenerate
+images, with full localisation support.
+
 ## Listing Composer
 
 The `ideation` service exposes a tag suggestion helper for Etsy listings. It

--- a/services/gateway/api.py
+++ b/services/gateway/api.py
@@ -8,7 +8,12 @@ from ..trend_scraper.service import (
 )
 from ..ideation.service import generate_ideas
 from ..ideation.api import app as ideation_app
-from ..image_gen.service import generate_images
+from ..image_gen.service import generate_images, list_images, delete_image
+from ..models import Idea
+from ..common.database import get_session
+from sqlmodel import select
+from fastapi import Request, HTTPException
+from pydantic import BaseModel
 from ..integration.service import create_sku, publish_listing
 from ..image_review.api import app as review_app
 from ..notifications.api import app as notifications_app
@@ -17,7 +22,6 @@ from ..ab_tests.api import app as ab_app
 from ..listing_composer.api import app as listing_app
 from ..social_generator.api import app as social_app
 from ..bulk_create.api import BulkCreateResponse, bulk_create as bulk_create_handler
-from fastapi import Request
 from ..trend_scraper.events import EVENTS
 from ..analytics.middleware import AnalyticsMiddleware
 
@@ -32,11 +36,44 @@ app.mount("/api/social", social_app)
 app.add_middleware(AnalyticsMiddleware)
 
 
+class ImageGenPayload(BaseModel):
+    idea_id: int
+    style: str
+    provider_override: str | None = None
+    model_version: str | None = None
+
+
+@app.post("/api/images/generate")
+async def api_generate_images(payload: ImageGenPayload):
+    return await generate_images(
+        payload.idea_id,
+        payload.style,
+        payload.provider_override,
+        payload.model_version,
+    )
+
+
+@app.get("/api/images/{idea_id}")
+async def api_list_images(idea_id: int):
+    return await list_images(idea_id)
+
+
+@app.delete("/api/images/{image_id}")
+async def api_delete_image(image_id: int):
+    ok = await delete_image(image_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return {"status": "deleted"}
+
+
 @app.post("/generate")
 async def generate():
     trends = await fetch_trends()
     ideas = await generate_ideas(trends)
-    images = await generate_images([i["description"] for i in ideas])
+    async with get_session() as session:
+        result = await session.exec(select(Idea))
+        idea_obj = result.first()
+    images = await generate_images(idea_obj.id, "")
     products = create_sku(images)
     listing = publish_listing(products[0])
     month = datetime.utcnow().strftime("%B").lower()

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,16 +1,39 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from .service import generate_images
+
+from .service import generate_images, list_images, delete_image
 from ..common.quotas import quota_middleware
+
+
+class GeneratePayload(BaseModel):
+    idea_id: int
+    style: str
+    provider_override: str | None = None
+    model_version: str | None = None
+
 
 app = FastAPI()
 app.middleware("http")(quota_middleware)
 
 
-class IdeaList(BaseModel):
-    ideas: list[str]
+@app.post("/generate")
+async def generate_endpoint(payload: GeneratePayload):
+    return await generate_images(
+        payload.idea_id,
+        payload.style,
+        payload.provider_override,
+        payload.model_version,
+    )
 
 
-@app.post("/images")
-async def images(data: IdeaList):
-    return await generate_images(data.ideas)
+@app.get("/{idea_id}")
+async def list_endpoint(idea_id: int):
+    return await list_images(idea_id)
+
+
+@app.delete("/{image_id}")
+async def delete_endpoint(image_id: int):
+    ok = await delete_image(image_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return {"status": "deleted"}

--- a/services/image_gen/service.py
+++ b/services/image_gen/service.py
@@ -1,29 +1,108 @@
-from typing import List, Dict
+import asyncio
+import logging
 import os
-from ..models import Product
+import uuid
+from typing import List, Dict, Optional
+
+import httpx
+
+from ..models import Image, Idea
 from ..common.database import get_session
+from sqlmodel import select
+
+logger = logging.getLogger(__name__)
+
+PLACEHOLDER_URL = "https://placehold.co/1024x1024?text=Image+Unavailable"
+STORAGE_DIR = os.getenv("IMAGE_STORAGE", "/data/images")
+DEFAULT_PROVIDER = os.getenv("PROVIDER", "openai").lower()
 
 
-async def generate_images(ideas: List[str]) -> List[Dict]:
-    if os.getenv("OPENAI_API_KEY"):
-        try:
-            import openai
+async def _download_and_store(url: str) -> str:
+    os.makedirs(STORAGE_DIR, exist_ok=True)
+    filename = f"{uuid.uuid4()}.png"
+    path = os.path.join(STORAGE_DIR, filename)
+    async with httpx.AsyncClient(timeout=60) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        with open(path, "wb") as f:
+            f.write(resp.content)
+    return path
 
-            responses = [
-                openai.Image.create(prompt=idea, n=1, size="512x512") for idea in ideas
-            ]
-            urls = [r["data"][0]["url"] for r in responses]
-        except Exception:
-            urls = ["http://example.com/image.png" for _ in ideas]
-    else:
-        urls = ["http://example.com/image.png" for _ in ideas]
 
-    products = []
+async def _generate_openai(prompt: str) -> str:
+    import openai
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+
+    def _call() -> Dict:
+        return openai.Image.create(prompt=prompt, n=1, size="1024x1024")
+
+    response = await asyncio.to_thread(_call)
+    return response["data"][0]["url"]
+
+
+async def _generate_gemini(prompt: str, model: Optional[str] = None) -> str:
+    api_key = os.getenv("GEMINI_API_KEY")
+    model = model or os.getenv("GEMINI_MODEL", "models/gemini-pro-vision")
+    endpoint = f"https://generativelanguage.googleapis.com/v1beta/{model}:generateImage"
+    params = {"key": api_key}
+    payload = {"prompt": {"text": prompt}, "size": "512x512"}
+    async with httpx.AsyncClient(timeout=60) as client:
+        resp = await client.post(endpoint, params=params, json=payload)
+    if resp.status_code == 429:
+        logger.warning("Gemini rate limit hit: %s", resp.text)
+        raise RuntimeError("rate limited")
+    resp.raise_for_status()
+    data = resp.json()
+    return data["data"][0]["url"]
+
+
+async def generate_images(
+    idea_id: int,
+    style: str,
+    provider_override: Optional[str] = None,
+    model_version: Optional[str] = None,
+) -> List[Dict]:
+    provider = (provider_override or DEFAULT_PROVIDER).lower()
     async with get_session() as session:
-        for idea, url in zip(ideas, urls):
-            product = Product(idea_id=0, image_url=url)
-            session.add(product)
+        idea = await session.get(Idea, idea_id)
+        if not idea:
+            raise ValueError("idea not found")
+    prompt = f"{style} {idea.description}".strip()
+    try:
+        if provider == "gemini":
+            url = await _generate_gemini(prompt, model_version)
+        else:
+            url = await _generate_openai(prompt)
+        stored = await _download_and_store(url)
+        async with get_session() as session:
+            image = Image(idea_id=idea_id, provider=provider, url=stored)
+            session.add(image)
             await session.commit()
-            await session.refresh(product)
-            products.append({"image_url": product.image_url})
-    return products
+            await session.refresh(image)
+        return [{"id": image.id, "url": image.url}]
+    except Exception as exc:
+        logger.error("Image generation failed: %s", exc)
+        return [{"id": None, "url": PLACEHOLDER_URL}]
+
+
+async def list_images(idea_id: int) -> List[Dict]:
+    async with get_session() as session:
+        result = await session.exec(select(Image).where(Image.idea_id == idea_id))
+        images = result.all()
+        return [{"id": img.id, "url": img.url, "provider": img.provider} for img in images]
+
+
+async def delete_image(image_id: int) -> bool:
+    async with get_session() as session:
+        image = await session.get(Image, image_id)
+        if not image:
+            return False
+        await session.delete(image)
+        await session.commit()
+    try:
+        if os.path.exists(image.url):
+            os.remove(image.url)
+    except OSError:
+        pass
+    return True

--- a/services/models.py
+++ b/services/models.py
@@ -20,6 +20,14 @@ class Idea(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class Image(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    idea_id: int
+    provider: str
+    url: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
 class Product(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     idea_id: int

--- a/status.md
+++ b/status.md
@@ -13,6 +13,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 5. Maintain architecture and schema diagrams.
+6. **High-Resolution Image Generation Service** – Integrate OpenAI and Gemini image providers with configurable selection. *(Integrations Engineer)*
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.

--- a/tests/e2e/images.spec.ts
+++ b/tests/e2e/images.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('images page generates and shows images', async ({ page }) => {
+  await page.route('**/api/images/generate', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 1, url: '/img.png' }]),
+    });
+  });
+
+  await page.goto('/images');
+  await page.fill('input[placeholder="Idea ID"]', '1');
+  await page.fill('input[placeholder="Style"]', 'cartoon');
+  await page.getByRole('button', { name: 'Generate' }).click();
+  await expect(page.locator('img')).toHaveCount(1);
+});

--- a/tests/e2e/navbar.spec.ts
+++ b/tests/e2e/navbar.spec.ts
@@ -6,6 +6,7 @@ test('home page navbar shows links and quota', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Generate' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Categories' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Design Ideas' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Images' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Suggestions' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Analytics' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Notifications' })).toBeVisible();

--- a/tests/test_image_gen_service.py
+++ b/tests/test_image_gen_service.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+import httpx
+from sqlmodel import select
+
+from services.image_gen.service import generate_images
+from services.common.database import init_db, get_session
+from services.models import Idea, Image
+
+
+@pytest.mark.asyncio
+async def test_generate_images_persists(monkeypatch, tmp_path):
+    await init_db()
+    async with get_session() as session:
+        idea = Idea(trend_id=0, description="test idea")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+
+    monkeypatch.setenv("OPENAI_API_KEY", "k")
+    monkeypatch.setenv("PROVIDER", "openai")
+    monkeypatch.setenv("IMAGE_STORAGE", str(tmp_path))
+
+    import openai
+
+    def fake_create(**kwargs):
+        return {"data": [{"url": "http://example.com/img.png"}]}
+
+    async def fake_get(self, url):
+        req = httpx.Request("GET", url)
+        return httpx.Response(status_code=200, content=b"data", request=req)
+
+    monkeypatch.setattr(openai.Image, "create", fake_create)
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    images = await generate_images(idea.id, "style")
+    assert images[0]["id"] is not None
+    assert os.path.exists(images[0]["url"])
+
+    async with get_session() as session:
+        res = await session.exec(select(Image))
+        saved = res.first()
+        assert saved is not None

--- a/tests/test_image_review.py
+++ b/tests/test_image_review.py
@@ -2,15 +2,17 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 
 from services.gateway.api import app as gateway_app
-from services.image_gen.service import generate_images
-from services.common.database import init_db
+from services.common.database import init_db, get_session
+from services.models import Product
 
 
 @pytest.mark.asyncio
 async def test_image_review_endpoints():
     await init_db()
-    # seed one product
-    await generate_images(["test idea"])
+    async with get_session() as session:
+        prod = Product(idea_id=0, image_url="/test.png")
+        session.add(prod)
+        await session.commit()
 
     transport = ASGITransport(app=gateway_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- add Image model and configurable OpenAI/Gemini image generation service
- expose /api/images endpoints and dashboard Images tab with i18n
- document provider selection and update sample env & status

## Testing
- `pytest tests/test_image_gen_service.py tests/test_image_review.py tests/test_gateway.py`
- `npm test --prefix client`
- `npx playwright test tests/e2e/images.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68be84549598832b9d50442ae9995496