### PR TITLE
feat: add high resolution image generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 OPENAI_API_KEY=
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-pro-vision
+PROVIDER=openai
 PRINTIFY_API_KEY=
 ETSY_API_KEY=
 DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/pod

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -29,6 +29,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/categories" className="hover:underline">{t('nav.categories')}</Link>
           <Link href="/design" className="hover:underline">{t('nav.designIdeas')}</Link>
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
+          <Link href="/images" className="hover:underline">{t('nav.images')}</Link>
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -5,6 +5,7 @@
     "categories": "Categories",
     "designIdeas": "Design Ideas",
     "suggestions": "Suggestions",
+    "images": "Images",
     "search": "Search",
     "analytics": "Analytics",
     "listings": "Listings",
@@ -121,5 +122,15 @@
     "uploading": "Uploading...",
     "success": "Created",
     "error": "Error"
+  },
+  "images": {
+    "title": "Images",
+    "ideaId": "Idea ID",
+    "style": "Style",
+    "provider": "Provider",
+    "default": "Default",
+    "generate": "Generate",
+    "delete": "Delete",
+    "regenerate": "Regenerate"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -5,6 +5,7 @@
     "categories": "Categorías",
     "designIdeas": "Ideas de diseño",
     "suggestions": "Sugerencias",
+    "images": "Imágenes",
     "search": "Buscar",
     "analytics": "Analíticas",
     "listings": "Publicaciones",
@@ -121,5 +122,15 @@
     "uploading": "Subiendo...",
     "success": "Creado",
     "error": "Error"
+  },
+  "images": {
+    "title": "Imágenes",
+    "ideaId": "ID de Idea",
+    "style": "Estilo",
+    "provider": "Proveedor",
+    "default": "Predeterminado",
+    "generate": "Generar",
+    "delete": "Eliminar",
+    "regenerate": "Regenerar"
   }
 }

--- a/client/pages/images/index.tsx
+++ b/client/pages/images/index.tsx
@@ -1,0 +1,84 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+export default function Images() {
+  const { t } = useTranslation('common');
+  const [ideaId, setIdeaId] = useState('');
+  const [style, setStyle] = useState('');
+  const [provider, setProvider] = useState('');
+  const [images, setImages] = useState<string[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+
+  const generate = async () => {
+    try {
+      const res = await axios.post<{ urls: string[] }>(`${api}/api/images/generate`, {
+        idea_id: Number(ideaId),
+        style,
+        provider_override: provider || undefined,
+      });
+      setImages(res.data.urls);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold mb-4">{t('images.title')}</h1>
+      <div className="flex flex-wrap gap-2 items-end">
+        <div>
+          <label className="block text-sm font-medium">{t('images.ideaId')}</label>
+          <input
+            name="ideaId"
+            value={ideaId}
+            onChange={e => setIdeaId(e.target.value)}
+            className="border p-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">{t('images.style')}</label>
+          <input
+            name="style"
+            value={style}
+            onChange={e => setStyle(e.target.value)}
+            className="border p-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium">{t('images.provider')}</label>
+          <select
+            value={provider}
+            onChange={e => setProvider(e.target.value)}
+            className="border p-2"
+          >
+            <option value="">{t('images.default')}</option>
+            <option value="openai">OpenAI</option>
+            <option value="gemini">Gemini</option>
+          </select>
+        </div>
+        <button onClick={generate} className="bg-blue-600 text-white px-4 py-2">
+          {t('images.generate')}
+        </button>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {images.map((url, idx) => (
+          <div key={idx} className="space-y-2">
+            <img src={url} alt={`generated-${idx}`} className="w-full h-auto" />
+            <div className="flex gap-2">
+              <button
+                onClick={() => setImages(imgs => imgs.filter((_, i) => i !== idx))}
+                className="bg-red-500 text-white px-2 py-1 text-sm"
+              >
+                {t('images.delete')}
+              </button>
+              <button onClick={generate} className="bg-gray-500 text-white px-2 py-1 text-sm">
+                {t('images.regenerate')}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -117,6 +117,26 @@ generated caption and image. The caption can be edited, copied to the clipboard
 and the image downloaded. The feature honours the user's auto-generation and
 social handle preferences.
 
+## High-Resolution Image Generation Service
+
+Images can be generated via **OpenAI** or **Google Gemini**. The default provider
+is configured with the `PROVIDER` environment variable (`openai` or `gemini`) and
+may be overridden per request. OpenAI uses `OPENAI_API_KEY` to request 1024x1024
+images. Gemini calls require `GEMINI_API_KEY` and `GEMINI_MODEL` and return at
+least 512x512 images. Generated files are saved to S3 when `S3_BUCKET` is set or
+to `/data/images` locally. If generation fails, a placeholder image URL is
+returned.
+
+### API
+
+- **POST `/api/images/generate`** – body `{ idea_id, style, provider_override? }`
+  returns `{ urls: string[] }`.
+
+### Dashboard
+
+The dashboard now features an **Images** tab for viewing, deleting and
+regenerating generated images.
+
 ## Listing Composer
 
 The `ideation` service exposes a tag suggestion helper for Etsy listings. It

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ black
 aiosqlite
 APScheduler
 Pillow
+httpx
+boto3

--- a/services/common/quotas.py
+++ b/services/common/quotas.py
@@ -9,7 +9,7 @@ PLAN_LIMITS = {"free": 20, "pro": 100}
 
 
 async def quota_middleware(request: Request, call_next):
-    if request.url.path != "/images" or request.method.upper() != "POST":
+    if request.url.path not in {"/images", "/generate"} or request.method.upper() != "POST":
         return await call_next(request)
 
     user_id = request.headers.get("X-User-Id")
@@ -19,7 +19,10 @@ async def quota_middleware(request: Request, call_next):
     body_bytes = await request.body()
     try:
         payload = json.loads(body_bytes)
-        count = len(payload.get("ideas", []))
+        if "ideas" in payload:
+            count = len(payload.get("ideas", []))
+        else:
+            count = 1
     except Exception:
         count = 1
     request._body = body_bytes  # allow downstream handlers to read body again

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+
 from .service import generate_images
 from ..common.quotas import quota_middleware
 
@@ -7,10 +8,13 @@ app = FastAPI()
 app.middleware("http")(quota_middleware)
 
 
-class IdeaList(BaseModel):
-    ideas: list[str]
+class ImageRequest(BaseModel):
+    idea_id: int
+    style: str
+    provider_override: str | None = None
 
 
-@app.post("/images")
-async def images(data: IdeaList):
-    return await generate_images(data.ideas)
+@app.post("/generate")
+async def generate(req: ImageRequest):
+    urls = await generate_images(req.idea_id, req.style, req.provider_override)
+    return {"urls": urls}

--- a/services/image_gen/service.py
+++ b/services/image_gen/service.py
@@ -1,29 +1,101 @@
-from typing import List, Dict
+import asyncio
+import logging
 import os
-from ..models import Product
+import uuid
+from typing import List, Optional
+
+import httpx
+
+from ..models import Idea, Image, Product
 from ..common.database import get_session
 
+logger = logging.getLogger(__name__)
 
-async def generate_images(ideas: List[str]) -> List[Dict]:
-    if os.getenv("OPENAI_API_KEY"):
+PLACEHOLDER_URL = "https://placehold.co/1024x1024?text=Image"
+
+
+async def _store_image(content: bytes, filename: str) -> str:
+    bucket = os.getenv("S3_BUCKET")
+    if bucket:
         try:
-            import openai
+            import boto3
 
-            responses = [
-                openai.Image.create(prompt=idea, n=1, size="512x512") for idea in ideas
-            ]
-            urls = [r["data"][0]["url"] for r in responses]
+            s3 = boto3.client("s3")
+            s3.put_object(Bucket=bucket, Key=filename, Body=content)
+            return f"s3://{bucket}/{filename}"
         except Exception:
-            urls = ["http://example.com/image.png" for _ in ideas]
-    else:
-        urls = ["http://example.com/image.png" for _ in ideas]
+            logger.exception("Failed to upload to S3")
+    storage_dir = os.getenv("IMAGE_STORAGE", "/data/images")
+    os.makedirs(storage_dir, exist_ok=True)
+    path = os.path.join(storage_dir, filename)
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
 
-    products = []
+
+async def _download_and_store(url: str) -> str:
+    filename = f"{uuid.uuid4()}.png"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+    return await _store_image(resp.content, filename)
+
+
+async def generate_images(
+    idea_id: int, style: str, provider_override: Optional[str] = None
+) -> List[str]:
+    provider = (provider_override or os.getenv("PROVIDER", "openai")).lower()
     async with get_session() as session:
-        for idea, url in zip(ideas, urls):
-            product = Product(idea_id=0, image_url=url)
-            session.add(product)
-            await session.commit()
-            await session.refresh(product)
-            products.append({"image_url": product.image_url})
-    return products
+        idea = await session.get(Idea, idea_id)
+    if not idea:
+        return [PLACEHOLDER_URL]
+    prompt = f"{style} {idea.description}".strip()
+    url = PLACEHOLDER_URL
+    if provider == "gemini":
+        api_key = os.getenv("GEMINI_API_KEY")
+        model = os.getenv("GEMINI_MODEL", "gemini-pro-vision")
+        if api_key:
+            try:
+                async with httpx.AsyncClient(timeout=30) as client:
+                    resp = await client.post(
+                        f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateImage",
+                        params={"key": api_key},
+                        json={"prompt": {"text": prompt}, "size": "512x512"},
+                    )
+                    if resp.status_code == 429:
+                        logger.error("Gemini rate limited")
+                    resp.raise_for_status()
+                    url = resp.json().get("data", [{}])[0].get("url", PLACEHOLDER_URL)
+            except Exception:
+                logger.exception("Gemini image generation failed")
+        else:
+            logger.error("GEMINI_API_KEY missing")
+    else:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if api_key:
+            try:
+                import openai
+
+                openai.api_key = api_key
+                response = await asyncio.to_thread(
+                    openai.Image.create, prompt=prompt, n=1, size="1024x1024"
+                )
+                url = response["data"][0]["url"]
+            except Exception:
+                logger.exception("OpenAI image generation failed")
+        else:
+            logger.error("OPENAI_API_KEY missing")
+    if url == PLACEHOLDER_URL:
+        stored_url = PLACEHOLDER_URL
+    else:
+        try:
+            stored_url = await _download_and_store(url)
+        except Exception:
+            logger.exception("Failed to store image")
+            stored_url = url
+    async with get_session() as session:
+        image = Image(idea_id=idea_id, provider=provider, url=stored_url)
+        session.add(image)
+        session.add(Product(idea_id=idea_id, image_url=stored_url))
+        await session.commit()
+    return [stored_url]

--- a/services/models.py
+++ b/services/models.py
@@ -31,6 +31,14 @@ class Product(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class Image(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    idea_id: int
+    provider: str
+    url: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
 class Listing(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     product_id: int

--- a/status.md
+++ b/status.md
@@ -13,6 +13,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 5. Maintain architecture and schema diagrams.
+6. **High-Resolution Image Generation Service** – Integrations Engineer to polish provider integration and storage.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.

--- a/tests/e2e/images.spec.ts
+++ b/tests/e2e/images.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('images tab allows generation', async ({ page }) => {
+  await page.route('**/api/images/generate', route => {
+    route.fulfill({ status: 200, body: JSON.stringify({ urls: ['http://example.com/img.png'] }) });
+  });
+  await page.goto('/');
+  await page.click('text=Images');
+  await page.fill('input[name="ideaId"]', '1');
+  await page.fill('input[name="style"]', 'modern');
+  await page.click('button:has-text("Generate")');
+  await expect(page.locator('img')).toHaveCount(1);
+});

--- a/tests/test_image_gen_service.py
+++ b/tests/test_image_gen_service.py
@@ -1,0 +1,82 @@
+import os
+from sqlmodel import select
+import pytest
+
+from services.image_gen.service import generate_images
+from services.models import Idea, Image
+from services.common.database import init_db, get_session
+
+
+@pytest.mark.asyncio
+async def test_generate_images_openai(monkeypatch, tmp_path):
+    await init_db()
+    os.environ["OPENAI_API_KEY"] = "test"
+    os.environ["PROVIDER"] = "openai"
+    monkeypatch.setenv("IMAGE_STORAGE", str(tmp_path))
+
+    def fake_create(**_):
+        return {"data": [{"url": "http://example.com/img.png"}]}
+
+    async def fake_get(url):
+        class Resp:
+            status_code = 200
+            content = b"img"
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    import openai
+    monkeypatch.setattr(openai.Image, "create", fake_create)
+    monkeypatch.setattr("httpx.AsyncClient.get", lambda self, url: fake_get(url))
+
+    async with get_session() as session:
+        idea = Idea(trend_id=1, description="desc")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+    urls = await generate_images(idea.id, "style")
+    assert urls
+    stored = urls[0]
+    assert stored.startswith(str(tmp_path))
+    async with get_session() as session:
+        result = await session.exec(select(Image))
+        images = result.all()
+        assert images and images[0].provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_provider_override(monkeypatch, tmp_path):
+    await init_db()
+    os.environ.pop("OPENAI_API_KEY", None)
+    os.environ["GEMINI_API_KEY"] = "gtest"
+    monkeypatch.setenv("IMAGE_STORAGE", str(tmp_path))
+
+    async def fake_post(*args, **kwargs):
+        class Resp:
+            status_code = 200
+            content = b"img"
+
+            def json(self):
+                return {"data": [{"url": "http://example.com/g.png"}]}
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr("httpx.AsyncClient.post", fake_post)
+    monkeypatch.setattr("httpx.AsyncClient.get", lambda self, url: fake_post())
+
+    async with get_session() as session:
+        idea = Idea(trend_id=1, description="desc")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+    urls = await generate_images(idea.id, "style", provider_override="gemini")
+    assert urls
+    async with get_session() as session:
+        result = await session.exec(select(Image))
+        images = result.all()
+        assert images and images[0].provider == "gemini"

--- a/tests/test_image_review.py
+++ b/tests/test_image_review.py
@@ -3,14 +3,19 @@ from httpx import AsyncClient, ASGITransport
 
 from services.gateway.api import app as gateway_app
 from services.image_gen.service import generate_images
-from services.common.database import init_db
+from services.common.database import init_db, get_session
+from services.models import Idea
 
 
 @pytest.mark.asyncio
 async def test_image_review_endpoints():
     await init_db()
-    # seed one product
-    await generate_images(["test idea"])
+    async with get_session() as session:
+        idea = Idea(trend_id=1, description="test idea")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+    await generate_images(idea.id, "default")
 
     transport = ASGITransport(app=gateway_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- add image generation service supporting OpenAI and Gemini with provider overrides
- expose `/api/images/generate` and Images dashboard tab for viewing and regenerating images
- document provider selection and update environment variables

## Testing
- `npm test --prefix client`
- `pytest`
- `npx playwright install --with-deps` *(failed: npm error canceled)*
- `npx playwright test` *(failed: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68be84549598832b9d50442ae9995496