### PR TITLE
feat: add pluggable image generation service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=
+GEMINI_API_KEY=
+PROVIDER=openai
 PRINTIFY_API_KEY=
 ETSY_API_KEY=
 DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/pod

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -31,6 +31,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Link href="/suggestions" className="hover:underline">{t('nav.suggestions')}</Link>
           <Link href="/search" className="hover:underline">{t('nav.search')}</Link>
           <Link href="/listings" className="hover:underline">{t('nav.listings')}</Link>
+          <Link href="/images" className="hover:underline">{t('nav.images')}</Link>
           <Link href="/analytics" className="hover:underline">{t('nav.analytics')}</Link>
           <Link href="/social-generator" className="hover:underline">{t('nav.socialGenerator')}</Link>
           <Link href="/ab_tests" className="hover:underline">{t('nav.abTests')}</Link>

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -12,7 +12,8 @@
     "notifications": "Notifications",
     "socialGenerator": "Social Generator",
     "settings": "Settings",
-    "searchPlaceholder": "Search..."
+    "searchPlaceholder": "Search...",
+    "images": "Images"
   },
   "index": {
     "trending": "Trending Keywords",
@@ -121,5 +122,11 @@
     "uploading": "Uploading...",
     "success": "Created",
     "error": "Error"
+  },
+  "images": {
+    "title": "Images",
+    "delete": "Delete",
+    "select": "Select",
+    "regenerate": "Regenerate"
   }
 }

--- a/client/locales/es/common.json
+++ b/client/locales/es/common.json
@@ -12,7 +12,8 @@
     "notifications": "Notificaciones",
     "socialGenerator": "Generador Social",
     "settings": "Configuración",
-    "searchPlaceholder": "Buscar..."
+    "searchPlaceholder": "Buscar...",
+    "images": "Imágenes"
   },
   "index": {
     "trending": "Palabras clave en tendencia",
@@ -121,5 +122,11 @@
     "uploading": "Subiendo...",
     "success": "Creado",
     "error": "Error"
+  },
+  "images": {
+    "title": "Imágenes",
+    "delete": "Eliminar",
+    "select": "Seleccionar",
+    "regenerate": "Regenerar"
   }
 }

--- a/client/pages/images/index.tsx
+++ b/client/pages/images/index.tsx
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+export default function Images() {
+  const { t } = useTranslation('common');
+  const [images, setImages] = useState<any[]>([]);
+  const api = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const ideaId = 1; // placeholder for demo
+
+  const load = async () => {
+    try {
+      const res = await axios.get(`${api}/api/images`, { params: { idea_id: ideaId } });
+      setImages(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const remove = async (id: number) => {
+    await axios.delete(`${api}/api/images/${id}`);
+    load();
+  };
+
+  const regenerate = async () => {
+    await axios.post(`${api}/api/images/generate`, { idea_id: ideaId, style: 'default' });
+    load();
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{t('images.title')}</h1>
+      <button onClick={regenerate} className="bg-blue-600 text-white px-4 py-2">
+        {t('images.regenerate')}
+      </button>
+      <div className="grid grid-cols-2 gap-4">
+        {images.map((img) => (
+          <div key={img.id} className="border p-2">
+            <img src={img.url} alt="" className="w-full" />
+            <div className="flex justify-between mt-2">
+              <button onClick={() => remove(img.id)} className="text-red-600">
+                {t('images.delete')}
+              </button>
+              <button className="text-green-600">{t('images.select')}</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -110,6 +110,20 @@ flowchart LR
     E --> F
 ```
 
+## Image Generation Service
+
+Images are generated via either **OpenAI gpt-image-1** or **Google Gemini**.
+The default provider is controlled by the `PROVIDER` environment variable
+(`openai` or `gemini`) and may be overridden per request using the
+`provider_override` field. OpenAI requests call `openai.Image.create` with a
+`1024x1024` size while Gemini requests invoke the Generative Language API with
+at least `512x512` dimensions. Generated images are persisted to S3 when
+`S3_BUCKET` is set, otherwise they are written to `/data/images`.
+
+If generation fails a placeholder image URL is returned. Records are stored in
+the `Image` table linked to `Idea` via `idea_id` and include the provider and
+storage URL.
+
 ## Frontend Page
 
 The `/social-generator` page lets sellers enter product details and preview the

--- a/services/common/quotas.py
+++ b/services/common/quotas.py
@@ -9,7 +9,7 @@ PLAN_LIMITS = {"free": 20, "pro": 100}
 
 
 async def quota_middleware(request: Request, call_next):
-    if request.url.path != "/images" or request.method.upper() != "POST":
+    if request.url.path not in {"/images", "/generate"} or request.method.upper() != "POST":
         return await call_next(request)
 
     user_id = request.headers.get("X-User-Id")
@@ -19,7 +19,8 @@ async def quota_middleware(request: Request, call_next):
     body_bytes = await request.body()
     try:
         payload = json.loads(body_bytes)
-        count = len(payload.get("ideas", []))
+        ideas = payload.get("ideas")
+        count = len(ideas) if isinstance(ideas, list) else 1
     except Exception:
         count = 1
     request._body = body_bytes  # allow downstream handlers to read body again

--- a/services/image_gen/api.py
+++ b/services/image_gen/api.py
@@ -1,16 +1,29 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import generate_images
+
+from .service import generate_images, list_images, delete_image
 from ..common.quotas import quota_middleware
 
 app = FastAPI()
 app.middleware("http")(quota_middleware)
 
 
-class IdeaList(BaseModel):
-    ideas: list[str]
+class GenerateRequest(BaseModel):
+    idea_id: int
+    style: str
+    provider_override: str | None = None
 
 
-@app.post("/images")
-async def images(data: IdeaList):
-    return await generate_images(data.ideas)
+@app.post("/generate")
+async def generate(data: GenerateRequest):
+    return await generate_images(data.idea_id, data.style, data.provider_override)
+
+
+@app.get("/")
+async def list_endpoint(idea_id: int):
+    return await list_images(idea_id)
+
+
+@app.delete("/{image_id}")
+async def delete_endpoint(image_id: int):
+    return await delete_image(image_id)

--- a/services/image_gen/service.py
+++ b/services/image_gen/service.py
@@ -1,29 +1,109 @@
-from typing import List, Dict
+import base64
+import logging
 import os
-from ..models import Product
+from uuid import uuid4
+from typing import List, Optional
+
+import httpx
+from sqlmodel import select
+
+from ..models import Idea, Image, Product
 from ..common.database import get_session
 
+logger = logging.getLogger(__name__)
 
-async def generate_images(ideas: List[str]) -> List[Dict]:
-    if os.getenv("OPENAI_API_KEY"):
+PLACEHOLDER_URL = "http://example.com/placeholder.png"
+
+
+async def _save_image(image_bytes: bytes) -> str:
+    bucket = os.getenv("S3_BUCKET")
+    filename = f"{uuid4().hex}.png"
+    if bucket:
         try:
-            import openai
+            import boto3
 
-            responses = [
-                openai.Image.create(prompt=idea, n=1, size="512x512") for idea in ideas
-            ]
-            urls = [r["data"][0]["url"] for r in responses]
-        except Exception:
-            urls = ["http://example.com/image.png" for _ in ideas]
-    else:
-        urls = ["http://example.com/image.png" for _ in ideas]
+            s3 = boto3.client("s3")
+            s3.put_object(Bucket=bucket, Key=filename, Body=image_bytes, ContentType="image/png")
+            return f"https://{bucket}.s3.amazonaws.com/{filename}"
+        except Exception:  # pragma: no cover - best effort
+            logger.exception("Failed to upload image to S3; falling back to local storage")
+    storage_dir = os.getenv("IMAGE_DIR", "/data/images")
+    os.makedirs(storage_dir, exist_ok=True)
+    path = os.path.join(storage_dir, filename)
+    with open(path, "wb") as f:
+        f.write(image_bytes)
+    return path
 
-    products = []
+
+def _get_provider(override: Optional[str]) -> str:
+    return (override or os.getenv("PROVIDER") or "openai").lower()
+
+
+def _openai_image(prompt: str) -> bytes:
+    import openai
+
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    response = openai.Image.create(
+        prompt=prompt,
+        size="1024x1024",
+        response_format="b64_json",
+    )
+    b64 = response["data"][0]["b64_json"]
+    return base64.b64decode(b64)
+
+
+async def _gemini_image(prompt: str, model: Optional[str] = None) -> bytes:
+    model = model or os.getenv("GEMINI_MODEL", "models/gemini-pro-vision")
+    api_key = os.getenv("GEMINI_API_KEY")
+    url = f"https://generativelanguage.googleapis.com/v1beta/{model}:generateImage?key={api_key}"
+    payload = {"prompt": {"text": prompt}, "size": {"width": 512, "height": 512}}
+    async with httpx.AsyncClient(timeout=60) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        b64 = data["data"][0]["b64_json"]
+        return base64.b64decode(b64)
+
+
+async def generate_images(idea_id: int, style: str, provider_override: Optional[str] = None) -> List[str]:
+    provider = _get_provider(provider_override)
     async with get_session() as session:
-        for idea, url in zip(ideas, urls):
-            product = Product(idea_id=0, image_url=url)
+        idea = await session.get(Idea, idea_id)
+        if not idea:
+            logger.error("Idea %s not found", idea_id)
+            return [PLACEHOLDER_URL]
+    prompt = f"{idea.description} in {style} style"
+    try:
+        if provider == "gemini":
+            image_bytes = await _gemini_image(prompt)
+        else:
+            image_bytes = _openai_image(prompt)
+        url = await _save_image(image_bytes)
+        async with get_session() as session:
+            image = Image(idea_id=idea_id, provider=provider, url=url)
+            session.add(image)
+            await session.commit()
+            await session.refresh(image)
+            product = Product(idea_id=idea_id, image_url=url)
             session.add(product)
             await session.commit()
-            await session.refresh(product)
-            products.append({"image_url": product.image_url})
-    return products
+        return [url]
+    except Exception:  # pragma: no cover - error path
+        logger.exception("Image generation failed")
+        return [PLACEHOLDER_URL]
+
+
+async def list_images(idea_id: int) -> List[dict]:
+    async with get_session() as session:
+        result = await session.exec(select(Image).where(Image.idea_id == idea_id))
+        return [img.model_dump() for img in result.all()]
+
+
+async def delete_image(image_id: int) -> dict:
+    async with get_session() as session:
+        image = await session.get(Image, image_id)
+        if image:
+            await session.delete(image)
+            await session.commit()
+            return {"status": "deleted"}
+    return {"status": "not_found"}

--- a/services/models.py
+++ b/services/models.py
@@ -20,6 +20,14 @@ class Idea(SQLModel, table=True):
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class Image(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    idea_id: int
+    provider: str
+    url: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
 class Product(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     idea_id: int

--- a/status.md
+++ b/status.md
@@ -13,6 +13,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 5. Maintain architecture and schema diagrams.
+6. **High-Resolution Image Generation Service** – Integrate configurable OpenAI and Gemini providers for image generation (Integrations Engineer).
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.

--- a/tests/e2e/images_tab.spec.ts
+++ b/tests/e2e/images_tab.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+const images = [
+  { id: 1, url: '/img1.png' },
+];
+
+test('images tab loads and can regenerate', async ({ page }) => {
+  await page.route('**/api/images*', route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(images) });
+    } else {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(['/img2.png']) });
+    }
+  });
+
+  await page.goto('/images');
+  await expect(page.getByText('Images')).toBeVisible();
+  await page.getByText('Regenerate').click();
+  await expect(page.getByText('Images')).toBeVisible();
+});

--- a/tests/e2e/quota.spec.ts
+++ b/tests/e2e/quota.spec.ts
@@ -8,7 +8,7 @@ test.beforeAll(async () => {
   await new Promise((resolve) => {
     const init = spawn('python', [
       '-c',
-      'import asyncio; from services.common.database import init_db; asyncio.run(init_db())',
+      'import asyncio; from services.common.database import init_db, get_session; from services.models import Idea;\nasync def run():\n    await init_db();\n    async with get_session() as s:\n        idea = Idea(trend_id=0, description="test");\n        s.add(idea);\n        await s.commit();\n        await s.refresh(idea)\nasyncio.run(run())',
     ]);
     init.on('exit', resolve);
   });
@@ -23,8 +23,8 @@ test.afterAll(() => {
 test('requests under quota succeed', async ({ request }) => {
   const uid = '301';
   for (let i = 0; i < 2; i++) {
-    const res = await request.post(`${api}/images`, {
-      data: { ideas: ['idea'] },
+    const res = await request.post(`${api}/generate`, {
+      data: { idea_id: 1, style: 's' },
       headers: { 'X-User-Id': uid },
     });
     expect(res.status()).toBe(200);
@@ -34,14 +34,14 @@ test('requests under quota succeed', async ({ request }) => {
 test('requests beyond quota are blocked', async ({ request }) => {
   const uid = '302';
   for (let i = 0; i < 20; i++) {
-    const res = await request.post(`${api}/images`, {
-      data: { ideas: ['idea'] },
+    const res = await request.post(`${api}/generate`, {
+      data: { idea_id: 1, style: 's' },
       headers: { 'X-User-Id': uid },
     });
     expect(res.status()).toBe(200);
   }
-  const res = await request.post(`${api}/images`, {
-    data: { ideas: ['idea'] },
+  const res = await request.post(`${api}/generate`, {
+    data: { idea_id: 1, style: 's' },
     headers: { 'X-User-Id': uid },
   });
   expect(res.status()).toBe(403);

--- a/tests/test_image_generation.py
+++ b/tests/test_image_generation.py
@@ -1,0 +1,68 @@
+import base64
+import os
+
+import openai
+import pytest
+
+from services.image_gen.service import generate_images
+from services.models import Idea, Image
+from services.common.database import init_db, get_session
+from sqlmodel import select
+
+
+@pytest.mark.asyncio
+async def test_generate_images_openai(monkeypatch, tmp_path):
+    os.environ['OPENAI_API_KEY'] = 'x'
+    os.environ['PROVIDER'] = 'openai'
+    os.environ['IMAGE_DIR'] = str(tmp_path)
+
+    fake = {"data": [{'b64_json': base64.b64encode(b'test').decode()}]}
+    monkeypatch.setattr(openai.Image, 'create', lambda **kwargs: fake)
+
+    await init_db()
+    async with get_session() as session:
+        idea = Idea(trend_id=0, description='idea')
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        idea_id = idea.id
+    urls = await generate_images(idea_id, 'style')
+    assert urls
+    assert os.path.exists(urls[0])
+    async with get_session() as session:
+        result = await session.exec(select(Image))
+        img = result.first()
+        assert img.provider == 'openai'
+
+
+@pytest.mark.asyncio
+async def test_generate_images_gemini(monkeypatch, tmp_path):
+    os.environ['GEMINI_API_KEY'] = 'y'
+    os.environ['PROVIDER'] = 'gemini'
+    os.environ['IMAGE_DIR'] = str(tmp_path)
+
+    class DummyResponse:
+        def json(self):
+            return {'data': [{'b64_json': base64.b64encode(b'gm').decode()}]}
+        def raise_for_status(self):
+            return None
+
+    async def fake_post(self, url, json):
+        return DummyResponse()
+
+    monkeypatch.setattr('httpx.AsyncClient.post', fake_post)
+
+    await init_db()
+    async with get_session() as session:
+        idea = Idea(trend_id=0, description='idea')
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        idea_id = idea.id
+    urls = await generate_images(idea_id, 'style')
+    assert urls
+    assert os.path.exists(urls[0])
+    async with get_session() as session:
+        result = await session.exec(select(Image))
+        img = result.first()
+        assert img.provider == 'gemini'

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -3,7 +3,7 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from services.image_gen.api import app as image_app
 from services.common.database import init_db, get_session
-from services.models import User
+from services.models import User, Idea
 
 
 @pytest.mark.asyncio
@@ -15,11 +15,17 @@ async def test_quota_enforcement():
             await session.delete(existing)
             await session.commit()
     transport = ASGITransport(app=image_app)
+    async with get_session() as session:
+        idea = Idea(trend_id=0, description="x")
+        session.add(idea)
+        await session.commit()
+        await session.refresh(idea)
+        idea_id = idea.id
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         for i in range(21):
             resp = await client.post(
-                "/images",
-                json={"ideas": ["idea"]},
+                "/generate",
+                json={"idea_id": idea_id, "style": "s"},
                 headers={"X-User-Id": "1"},
             )
             if i < 20:


### PR DESCRIPTION
## Summary
- add Image model and provider-selectable image generation service supporting OpenAI and Gemini
- expose /api/images endpoints and wire up gateway and UI Images tab
- document provider configuration and update environment samples

## Testing
- `pytest`
- `npm test --prefix client`
- `npx playwright test` *(fails: Need to install playwright package)*

------
https://chatgpt.com/codex/tasks/task_e_68be84549598832b9d50442ae9995496