### PR TITLE
feat: automate sku creation and listing publish pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 OPENAI_API_KEY=
 PRINTIFY_API_KEY=
 ETSY_API_KEY=
+GEMINI_API_KEY=
 DATABASE_URL=postgresql+asyncpg://user:pass@db:5432/pod
 REDIS_URL=redis://redis:6379/0

--- a/client/__tests__/PublishStep.test.tsx
+++ b/client/__tests__/PublishStep.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import PublishStep from '../components/PublishStep';
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key.split('.').pop() }),
+}));
+
+test('publishes with price and tags', () => {
+  const onPublish = jest.fn();
+  render(<PublishStep product={{ mockups: ['img'] }} onPublish={onPublish} />);
+  const price = screen.getByRole('spinbutton');
+  fireEvent.change(price, { target: { value: '20' } });
+  const tags = screen.getByRole('textbox');
+  fireEvent.change(tags, { target: { value: 'one,two' } });
+  fireEvent.click(screen.getByText('publishNow'));
+  expect(onPublish).toHaveBeenCalledWith({ price: 20, tags: ['one', 'two'] });
+});

--- a/client/components/PublishStep.tsx
+++ b/client/components/PublishStep.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'next-i18next';
+
+interface Props {
+  product: { mockups: string[] };
+  onPublish: (data: { price: number; tags: string[] }) => void;
+  onSchedule?: () => void;
+}
+
+export default function PublishStep({ product, onPublish, onSchedule }: Props) {
+  const { t } = useTranslation('common');
+  const [price, setPrice] = useState(0);
+  const [tags, setTags] = useState('');
+
+  const submit = () => {
+    const tagList = tags
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+    onPublish({ price, tags: tagList });
+  };
+
+  return (
+    <div>
+      <div className="flex gap-2">
+        {product.mockups.map(src => (
+          <img key={src} src={src} alt="mockup" className="w-24 h-24" />
+        ))}
+      </div>
+      <div className="mt-2">
+        <label>{t('publish.price')}</label>
+        <input
+          type="number"
+          value={price}
+          onChange={e => setPrice(Number(e.target.value))}
+          className="border ml-2 p-1"
+        />
+      </div>
+      <div className="mt-2">
+        <label>{t('publish.tags')}</label>
+        <input
+          value={tags}
+          onChange={e => setTags(e.target.value)}
+          className="border ml-2 p-1"
+        />
+      </div>
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={submit}
+          className="bg-blue-600 text-white px-4 py-2"
+        >
+          {t('publish.publishNow')}
+        </button>
+        {onSchedule && (
+          <button
+            type="button"
+            onClick={onSchedule}
+            className="bg-gray-200 px-4 py-2"
+          >
+            {t('publish.schedule')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/locales/en/common.json
+++ b/client/locales/en/common.json
@@ -55,6 +55,12 @@
     "save": "Save Draft",
     "language": "Language"
   },
+  "publish": {
+    "price": "Price",
+    "tags": "Tags",
+    "publishNow": "Publish Now",
+    "schedule": "Schedule"
+  },
   "analytics": {
     "title": "Analytics Dashboard",
     "views": "Page Views",

--- a/docs/internal_docs.md
+++ b/docs/internal_docs.md
@@ -40,11 +40,16 @@ Real Printify and Etsy clients live in `packages/integrations/printify.py` and `
 
 ```mermaid
 flowchart LR
-    A[Product Data] --> B[Printify API]
-    B --> C[SKU]
-    D[Listing Data] --> E[Etsy API]
-    E --> F[Listing URL]
+    I[Idea] --> IM[Generated Images]
+    IM --> P[Printify Product]
+    P --> M[Gemini Mock-up]
+    M --> L[Etsy Listing]
 ```
+
+Images produced by the `image_gen` service are uploaded to Printify, which
+returns variant identifiers. For each variant, a lifestyle mock-up is created
+via the Gemini image API and set as the primary image before the final Etsy
+listing is published.
 
 ## Bulk Product Creation
 

--- a/packages/integrations/gemini.py
+++ b/packages/integrations/gemini.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Google Gemini image API integration."""
+
+import logging
+import os
+from typing import Dict
+
+import httpx
+
+logger = logging.getLogger(__name__)
+API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+
+
+def _generate_mockup_real(api_key: str, prompt: str) -> str:
+    params = {"key": api_key}
+    payload: Dict[str, str] = {"prompt": prompt}
+    try:
+        resp = httpx.post(
+            f"{API_BASE}/models/gemini-pro-vision:generateImage",
+            params=params,
+            json=payload,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Simplified extraction assuming first image URL in response
+        return data.get("data", [{}])[0].get("url", "")
+    except httpx.HTTPError as exc:
+        logger.error("Gemini API error: %s", exc)
+        raise
+
+
+def _generate_mockup_stub(prompt: str) -> str:
+    logger.info("GEMINI_API_KEY missing; returning stub image")
+    return "http://example.com/mockup.png"
+
+
+def generate_mockup(prompt: str) -> str:
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return _generate_mockup_stub(prompt)
+    return _generate_mockup_real(api_key, prompt)

--- a/packages/integrations/printify.py
+++ b/packages/integrations/printify.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 import httpx
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 API_BASE = "https://api.printify.com/v1"
+
+
+class ProductBlueprint(BaseModel):
+    """Simple blueprint descriptor for product variants."""
+
+    blueprint_id: str
+    colors: List[str]
+    sizes: List[str]
 
 
 def _create_sku_real(api_key: str, products: List[Dict]) -> List[Dict]:
@@ -41,3 +50,59 @@ def get_printify_client():
     if not api_key:
         return _create_sku_stub
     return lambda products: _create_sku_real(api_key, products)
+
+
+def _create_product_real(
+    api_key: str,
+    idea_id: str,
+    image_ids: List[str],
+    blueprint_id: str,
+    variants: List[str],
+    mockups: Optional[List[str]] = None,
+) -> Dict:
+    """Call Printify to create a product with the given variants."""
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {
+        "title": f"Idea {idea_id}",
+        "blueprint_id": blueprint_id,
+        "print_provider_id": 1,
+        "variants": [{"id": v} for v in variants],
+        "images": [{"src": img} for img in (mockups or image_ids)],
+    }
+    try:
+        resp = httpx.post(
+            f"{API_BASE}/products.json", json=payload, headers=headers, timeout=10
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        variant_ids = [str(v.get("id", "")) for v in data.get("variants", [])]
+        return {"product_id": str(data.get("id", "")), "variant_ids": variant_ids}
+    except httpx.HTTPError as exc:
+        logger.error("Printify API error: %s", exc)
+        raise
+
+
+def _create_product_stub(
+    idea_id: str,
+    image_ids: List[str],
+    blueprint_id: str,
+    variants: List[str],
+    mockups: Optional[List[str]] = None,
+) -> Dict:
+    logger.info("PRINTIFY_API_KEY missing; returning stub product")
+    variant_ids = [f"stub-var-{i}" for i, _ in enumerate(variants, start=1)]
+    return {"product_id": "stub-product", "variant_ids": variant_ids}
+
+
+def create_product(
+    idea_id: str,
+    image_ids: List[str],
+    blueprint_id: str,
+    variants: List[str],
+    mockups: Optional[List[str]] = None,
+) -> Dict:
+    api_key = os.getenv("PRINTIFY_API_KEY")
+    if not api_key:
+        return _create_product_stub(idea_id, image_ids, blueprint_id, variants, mockups)
+    return _create_product_real(api_key, idea_id, image_ids, blueprint_id, variants, mockups)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 pytrends
 openai
+httpx
 celery
 redis
 sqlmodel

--- a/services/integration/api.py
+++ b/services/integration/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from .service import create_sku, publish_listing
+from .service import create_sku, publish_listing, create_printify_product
 
 
 app = FastAPI()
@@ -8,6 +8,13 @@ app = FastAPI()
 
 class ProductList(BaseModel):
     products: list[dict]
+
+
+class ProductCreate(BaseModel):
+    idea_id: str
+    image_ids: list[str]
+    blueprint_id: str
+    variants: list[str]
 
 
 @app.post("/sku")
@@ -32,3 +39,15 @@ async def publish_listing_legacy(product: dict):
     """Legacy endpoint for backward compatibility."""
     listing = publish_listing(product)
     return {"listing": listing.get("etsy_url"), "product": listing}
+
+
+@app.post("/api/printify/products/create")
+async def create_printify_product_endpoint(data: ProductCreate):
+    return create_printify_product(
+        data.idea_id, data.image_ids, data.blueprint_id, data.variants
+    )
+
+
+@app.post("/api/etsy/listings/publish")
+async def publish_listing_endpoint(product: dict):
+    return publish_listing(product)

--- a/services/integration/service.py
+++ b/services/integration/service.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import List
 
-from packages.integrations.printify import get_printify_client
+from packages.integrations.printify import (
+    get_printify_client,
+    create_product as printify_create_product,
+)
 from packages.integrations.etsy import get_etsy_client
+from packages.integrations import gemini
 
 
 def create_sku(products: List[dict]) -> List[dict]:
@@ -14,3 +18,17 @@ def create_sku(products: List[dict]) -> List[dict]:
 def publish_listing(product: dict) -> dict:
     client = get_etsy_client()
     return client(product)
+
+
+def create_printify_product(
+    idea_id: str,
+    image_ids: List[str],
+    blueprint_id: str,
+    variants: List[str],
+) -> dict:
+    """Create a Printify product and upload mock-up images."""
+
+    mockups = [
+        gemini.generate_mockup(f"{blueprint_id} variant {v}") for v in variants
+    ]
+    return printify_create_product(idea_id, image_ids, blueprint_id, variants, mockups)

--- a/status.md
+++ b/status.md
@@ -13,6 +13,7 @@ This file tracks the remaining work required to bring PODPusher to production re
 3. **Notification & Scheduling System** – Implement backend scheduling and a notification service to alert users about quota resets, trending products, and scheduled posts or product launches.
 4. **Localization & Internationalization (i18n)** – Extend translation support beyond current pages and adapt currency formats for different locales.
 5. Maintain architecture and schema diagrams.
+6. **Integrations Engineer** – Expand Printify and Etsy integrations with Gemini mock-up support and publishing workflow.
 
 ## Completed
 - A/B Testing Support – Flexible engine with experiment types, weighted traffic and scheduling.

--- a/tests/test_publication_pipeline.py
+++ b/tests/test_publication_pipeline.py
@@ -1,0 +1,90 @@
+import logging
+from importlib import reload
+
+import httpx
+import pytest
+
+from services.integration import service
+from packages.integrations import printify as printify_mod
+from packages.integrations import etsy as etsy_mod
+from packages.integrations import gemini as gemini_mod
+
+
+def _reload_modules():
+    reload(printify_mod)
+    reload(etsy_mod)
+    reload(service)
+
+
+@pytest.fixture
+def mock_gemini(monkeypatch):
+    calls = []
+
+    def fake_generate(prompt: str) -> str:
+        calls.append(prompt)
+        return f"http://mock/{len(calls)}.png"
+
+    monkeypatch.setattr(gemini_mod, "generate_mockup", fake_generate)
+    return calls
+
+
+def test_create_printify_product(monkeypatch, mock_gemini):
+    monkeypatch.setenv("PRINTIFY_API_KEY", "key")
+    _reload_modules()
+
+    def fake_post(url, json, headers, timeout):
+        assert headers["Authorization"] == "Bearer key"
+        return httpx.Response(
+            200,
+            json={"id": "prod1", "variants": [{"id": "v1"}, {"id": "v2"}]},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(printify_mod.httpx, "post", fake_post)
+    result = service.create_printify_product(
+        "idea", ["img1"], "bp1", ["v1", "v2"]
+    )
+    assert result["product_id"] == "prod1"
+    assert result["variant_ids"] == ["v1", "v2"]
+    assert len(mock_gemini) == 2
+
+
+def test_create_printify_product_error(monkeypatch, mock_gemini):
+    monkeypatch.setenv("PRINTIFY_API_KEY", "key")
+    _reload_modules()
+
+    def fake_post(url, json, headers, timeout):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(printify_mod.httpx, "post", fake_post)
+    with pytest.raises(httpx.HTTPError):
+        service.create_printify_product("idea", ["img"], "bp", ["v1"])
+
+
+def test_publish_listing(monkeypatch):
+    monkeypatch.setenv("ETSY_API_KEY", "key")
+    _reload_modules()
+
+    def fake_post(url, json, headers, timeout):
+        return httpx.Response(
+            200,
+            json={"url": "http://etsy/listing"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(etsy_mod.httpx, "post", fake_post)
+    product = {"title": "Test"}
+    result = service.publish_listing(product)
+    assert result["etsy_url"] == "http://etsy/listing"
+
+
+def test_publish_listing_error(monkeypatch):
+    monkeypatch.setenv("ETSY_API_KEY", "key")
+    _reload_modules()
+
+    def fake_post(url, json, headers, timeout):
+        raise httpx.HTTPError("err")
+
+    monkeypatch.setattr(etsy_mod.httpx, "post", fake_post)
+    with pytest.raises(httpx.HTTPError):
+        service.publish_listing({"title": "T"})


### PR DESCRIPTION
## Summary
- integrate Gemini mock-up generation and expose env `GEMINI_API_KEY`
- extend Printify client and integration service for blueprint product creation
- add dashboard publish step with price and scheduling controls

## Testing
- `pytest tests/test_publication_pipeline.py tests/test_integration_service.py`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68be847b4e18832bbe88fa368eda13ca