### PR TITLE
Fix pytest asyncio dependency token

### DIFF
--- a/client/next-env.d.ts
+++ b/client/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -20,7 +20,8 @@
     "types": [
       "node",
       "jest"
-    ]
+    ],
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ redis
 sqlmodel
 psycopg[binary]
 pytest
-pytest - asyncio
+pytest-asyncio
+python-multipart
 flake8
 black
 aiosqlite

--- a/tests/test_bulk_api.py
+++ b/tests/test_bulk_api.py
@@ -1,9 +1,12 @@
+import csv
+import io
 import json
+
 import pytest
 from httpx import AsyncClient, ASGITransport
 
-from services.gateway.api import app as gateway_app
 from services.common.database import init_db
+from services.gateway.api import app as gateway_app
 
 
 @pytest.mark.asyncio
@@ -41,11 +44,10 @@ async def test_bulk_create_csv_api():
     await init_db()
     transport = ASGITransport(app=gateway_app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        variants = json.dumps([{ "sku": "s1", "price": 9.99 }])
+        variants = json.dumps([{"sku": "s1", "price": 9.99}])
         images = json.dumps(["http://example.com/img.png"])
-        import io, csv as csvmod
         out = io.StringIO()
-        writer = csvmod.writer(out)
+        writer = csv.writer(out)
         writer.writerow(["title", "description", "price", "category", "variants", "image_urls"])
         writer.writerow(["Shirt", "Desc", 9.99, "apparel", variants, images])
         writer.writerow(["", "Bad", 9.99, "apparel", variants, images])

--- a/tests/test_bulk_service.py
+++ b/tests/test_bulk_service.py
@@ -1,4 +1,7 @@
+import csv
+import io
 import json
+
 from services.bulk_create.service import (
     parse_products_from_csv,
     parse_products_from_json,
@@ -6,12 +9,11 @@ from services.bulk_create.service import (
 
 
 def test_parse_products_from_csv():
-    variants = json.dumps([{ "sku": "s1", "price": 9.99 }])
+    variants = json.dumps([{"sku": "s1", "price": 9.99}])
     images = json.dumps(["http://example.com/img.png"])
-    import io, csv as csvmod
 
     output = io.StringIO()
-    writer = csvmod.writer(output)
+    writer = csv.writer(output)
     writer.writerow(["title", "description", "price", "category", "variants", "image_urls"])
     writer.writerow(["Shirt", "Desc", 9.99, "apparel", variants, images])
     writer.writerow(["", "Bad", 9.99, "apparel", variants, images])

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 
 EN_FILE = Path('client/locales/en/common.json')

--- a/tests/test_listing_draft_service.py
+++ b/tests/test_listing_draft_service.py
@@ -1,13 +1,19 @@
-import asyncio
 import pytest
+
 from services.common.database import init_db
-from services.listing_composer.service import DraftPayload, save_draft, get_draft
+from services.listing_composer.service import DraftPayload, get_draft, save_draft
 
 
 @pytest.mark.asyncio
 async def test_save_and_get_draft():
     await init_db()
-    payload = DraftPayload(title='t', description='d', tags=['a'], language='en', field_order=['title','description','tags'])
+    payload = DraftPayload(
+        title="t",
+        description="d",
+        tags=["a"],
+        language="en",
+        field_order=["title", "description", "tags"],
+    )
     draft = await save_draft(payload)
     fetched = await get_draft(draft.id)
     assert fetched is not None

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -1,8 +1,8 @@
-import os
 import pytest
 from httpx import AsyncClient, ASGITransport
+
+from services.common.database import get_session, init_db
 from services.image_gen.api import app as image_app
-from services.common.database import init_db, get_session
 from services.models import User
 
 


### PR DESCRIPTION
## Summary
- replace the malformed `pytest - asyncio` entry in `requirements.txt` with the correct `pytest-asyncio`
- add the missing `python-multipart` dependency so FastAPI form parsing tests can run

## Testing
- pip install -r requirements.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf7ac75b58832b866bc32bc76de752