### PR TITLE
[codex] refresh paused-project mainline state

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -301,13 +301,13 @@ A feature or pull request is DONE when:
 
 ## 19 | Status & Next Steps
 
-- **Pending pull requests:** new PRs from Codex for user quota features and the image review & tagging feature await review and merge.
-- **Backend_Coder:** integrate real Printify and Etsy APIs by replacing stubs in `services/integration/service.py`; implement the social media generator service; enhance analytics endpoints to return real metrics; remove placeholder code once integrations pass tests.
-- **Frontend_Coder:** finalise UI components for user quota display, the image review & rating tool, listing composer enhancements, social media generator, and analytics dashboard improvements.
-- **Integrations_Engineer:** build Printify, Etsy (with OAuth flow), and Stripe billing integrations with robust authentication and error handling.
-- **QA:** expand unit, integration and e2e tests to cover all new features and verify system performance and reliability.
-- **Docs_Writer:** update `/docs/internal_docs.md` with the latest architecture and features, and document new services.
-- **Additional improvements:** add structured logging, health checks and metrics across services, finalise listing composer updates, and remove all stubs after testing completes.
+- **Pending pull requests:** no active local merge candidates remain for the historical quota or image-review slices; both are already present on main. The only preserved manual-triage backlog is `codex/recovery-snapshot-20260325` and `codex/recovery-local-recreate-pr70-20260326`.
+- **Backend_Coder:** resume with the auth-derived identity hardening slice and keep integration stub reduction behind the existing verification gates.
+- **Frontend_Coder:** resume by removing remaining default internal-user fallback behavior in shared transport and settings/oauth flows.
+- **Integrations_Engineer:** prepare one credential-backed staging smoke run once Platform-QA confirms workflow contract and secrets ownership.
+- **QA:** keep backend auth/quota coverage green, then re-run staging smoke contract and integration suites as external blockers clear.
+- **Docs_Writer:** keep `status.md`, `planning.md`, and the control-plane docs synced to the live audit; update `/docs/internal_docs.md` only when service behavior changes.
+- **Additional improvements:** designate one clean `main`-attached integration worktree, archive or replay the preserved recovery branches deliberately, and avoid starting new work from detached maintenance checkouts.
 
 ---
 

--- a/docs/automation_control_plane.md
+++ b/docs/automation_control_plane.md
@@ -11,17 +11,20 @@ required before any runner resumes.
 At the time of this update, `mainline-audit --json` reports:
 
 - State: `ACTIVE`
-- local `main` at `1d3ed67...`
+- local `main` at `3e890f8...`
 - `origin/main` matches local `main`
-- canonical integration worktree: `/mnt/d/Users/Bear/.codex-data/worktrees/c0b6/PODPusher`
 - no active newer-than-main drift
+- detached archival worktrees already at `3e890f8...` exist, but they are
+  duplicate baseline copies rather than promotable drift
+- this maintenance checkout remains detached at `e380c72...`, so it is not the
+  canonical integration worktree
 - older unmerged backlog:
   - `codex/recovery-snapshot-20260325` at `837e167acd8b984825ba734013bef228ceab0060`
   - `codex/recovery-local-recreate-pr70-20260326` at `c7b5000cc0e32d164ad3ed6ef6c667af27dc3902`
 - always-on watchdog: `podpusher-mainline-watchdog` runs hourly as a read-only stall detector and opens an inbox note on clean or stalled snapshots.
 
 The repo-owned mainline is not frozen. Work-producing automations may proceed
-as long as they keep the live audit clean.
+once they start from a clean attached worktree and keep the live audit clean.
 
 ## Operating Rules
 
@@ -40,8 +43,8 @@ as long as they keep the live audit clean.
 
 1. `./scripts/codex_wsl_tasks.sh mainline-audit --json` shows no active
    newer-than-main drift and no `main` checkout conflict.
-2. The intended integration worktree is clean and attached to a named `codex/*`
-   branch.
+2. The intended integration worktree is clean and attached to `main` or a
+   named `codex/*` branch.
 3. `./scripts/codex_wsl_tasks.sh branch-gate` passes from that worktree.
 4. `./scripts/codex_wsl_tasks.sh mainline-sweep --verify` succeeds.
 5. `./scripts/codex_wsl_tasks.sh origin-reconcile` succeeds or no-ops only after
@@ -55,14 +58,14 @@ not to repair them.
 
 ## Resume Order
 
-1. `podpusher-mainline-sweep`
-2. `origin-reconcile`
-3. `podpusher-coordinator`
-4. `podpusher-backend-lane`
-5. `podpusher-frontend-lane`
-6. `podpusher-platform-qa-lane`
-7. `podpusher-integrations-lane`
-8. `podpusher-cleanup`
+1. `podpusher-mainline-watchdog`
+2. `podpusher-coordinator`
+3. `podpusher-backend-lane`
+4. `podpusher-frontend-lane`
+5. `podpusher-platform-qa-lane`
+6. `podpusher-integrations-lane`
+7. `podpusher-cleanup`
+8. `podpusher-mainline-sweep` / `origin-reconcile` on demand when new tracked drift appears
 
 ## Structured Stop Record
 
@@ -86,7 +89,7 @@ Audit all PODPusher automations and treat any future deadlock as a control-plane
 3. Use `mainline-audit` as the only live source of truth for branch drift, checked-out `main`, and dirty worktrees.
 4. Do not weaken `mainline_tools.py` guardrails; fix the workflow topology instead.
 5. Require a dedicated clean integration worktree and a single lease/lock for `mainline-sweep --verify` and `origin-reconcile`.
-6. Resume work-producing automations only after the active newer-than-main branch is folded and verified.
+6. Resume work-producing automations only after the active newer-than-main branch is folded and verified, or immediately when the audit already reports a clean mainline.
 7. Report every run with one structured record: automation id, timestamp, branch, HEAD SHA, blocker, next owner action, and resume eligibility.
 8. Keep backlog branches and scratch worktrees out of the active sweep path; triage them separately after the active drift is resolved.
 9. Optimize for throughput by preventing retry loops, reducing duplicate runs, and making the coordinator the only resume authority.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Realigned local `main` with `origin/main` after the project pause, confirmed the quota and image-review slices are already present on main, and refreshed the control-plane docs around the live `3e890f8` baseline with only the two preserved recovery branches left for manual triage.
 - Added an hourly `podpusher-mainline-watchdog` automation and refreshed the automation control-plane snapshot so stalls surface as inbox items instead of going silent.
 - Excluded repo-local virtualenv and Node toolchain directories from flake8 so `mainline-verify` no longer linted vendored dependencies.
 - Refreshed the mainline control-plane docs from the live git state, cleared the obsolete freeze snapshot, and optimized `mainline-audit` to avoid scanning every worktree status on each run.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # PODPusher Delivery Roadmap
 
-Last updated: March 27, 2026 (America/New_York)
+Last updated: April 5, 2026 (America/New_York)
 Owner: PODPusher Coordinator (`podpusher-delivery`)
 
 ## Coordination Objective
@@ -14,11 +14,13 @@ Run a four-lane board with exactly one active slice per lane and explicit depend
 
 ## Automation Control State
 
-The automation layer is active because the live mainline audit is clean. Product
-lane assignments below remain the authoritative backlog, but any future pause
-still depends on `mainline-audit` reporting active newer-than-main drift or a
-`main` checkout conflict. See [docs/automation_control_plane.md](./automation_control_plane.md)
-for the shared resume contract.
+The automation layer is restart-ready because local `main` now matches
+`origin/main` at `3e890f8`. Product lane assignments below remain the
+authoritative backlog. The remaining control-plane work is housekeeping:
+reattach one clean integration worktree to `main`, keep the watchdog active,
+and triage the two preserved recovery branches outside the sweep path. See
+[docs/automation_control_plane.md](./automation_control_plane.md) for the shared
+resume contract.
 
 Ordering rationale:
 - Backend auth/identity behavior must stay stable before frontend removes any remaining fallback assumptions.
@@ -39,10 +41,11 @@ Ordering rationale:
 - Staging smoke still requires confirmed ownership for repository secrets: `OPENAI_API_KEY`, `ETSY_CLIENT_ID`, `ETSY_ACCESS_TOKEN`, `ETSY_SHOP_ID`, `PRINTIFY_API_KEY`, `PRINTIFY_SHOP_ID`.
 - A human/authorized operator is still required for first `workflow_dispatch` execution evidence.
 - Some local environments still cannot run full billing collections due missing `stripe` dependency.
-- Mainline convergence is frozen until `/mnt/d/Users/Bear/Documents/GitHub/PODPusher` frees `main` and the active newer-than-main branch `codex/backend-auth-identity` is either folded or explicitly blocked.
+- Mainline drift is no longer the blocker: local `main` now matches `origin/main` at `3e890f8`, but merge-oriented work must resume from a clean `main`-attached worktree instead of a detached maintenance checkout.
 
 ## Cross-Lane Conflict Risks
 
 - Parallel backend/frontend edits in auth identity paths can reintroduce inconsistent fallback behavior.
 - Parallel integrations/platform-qa edits can drift smoke workflow, docs, and test contract expectations.
 - Detached worktree planner updates can silently diverge from mainline docs unless consolidated each sweep.
+- Restarting work from an older detached checkout can resurrect pre-main history; use `main` or a named `codex/*` branch only.

--- a/docs/source_of_truth_integration.md
+++ b/docs/source_of_truth_integration.md
@@ -220,14 +220,18 @@ disallowed.
 
 The live `mainline-audit --json` snapshot now reports:
 
-- local `main` at `0b7f99a...`
+- local `main` at `3e890f8...`
 - `origin/main` at the same commit
-- `main` checked out in the canonical integration worktree at
-  `/mnt/d/Users/Bear/.codex-data/worktrees/dd0c/PODPusher`
 - active newer-than-main tracked branches: none
+- detached archival worktrees already at `3e890f8...` are duplicate baseline
+  copies rather than promotable drift
+- this maintenance checkout at `/mnt/d/Users/Bear/Documents/GitHub/PODPusher`
+  remains detached at `e380c72...` and should not be used for
+  `mainline-sweep --verify` or `origin-reconcile`
 - older unmerged backlog branches that still require deliberate triage:
   - `codex/recovery-snapshot-20260325` at `837e167acd8b984825ba734013bef228ceab0060`
   - `codex/recovery-local-recreate-pr70-20260326` at `c7b5000cc0e32d164ad3ed6ef6c667af27dc3902`
 
-The live audit is clean, so `origin-reconcile` may proceed from the canonical
-worktree after the verification ladder passes.
+The live audit is clean enough to restart the control plane, but merge-oriented
+work should resume from a clean checkout attached to `main` or a named
+`codex/*` branch after the verification ladder passes.

--- a/planning.md
+++ b/planning.md
@@ -1,23 +1,26 @@
 # PODPusher Mainline Recovery Plan
 
-Last updated: March 27, 2026 (America/New_York)
+Last updated: April 5, 2026 (America/New_York)
 Owner: PODPusher Coordinator (`podpusher-delivery`)
 
 ## Objective
 
-Restore unattended code delivery to `origin/main` by fixing the mainline control plane, not by weakening merge gates.
+Resume unattended code delivery from the current remote baseline by keeping
+`main` aligned with `origin/main` and moving stale recovery branches out of the
+critical path.
 
 ## Current Diagnosis
 
-The delivery system is stalling for process reasons:
+The delivery system is now restartable, but the control plane still needs
+housekeeping discipline:
 
-1. The repo already has a fail-closed mainline gate (`branch-gate`, `mainline-audit`, `mainline-sweep`, `origin-reconcile`), but the topology does not always satisfy the gate.
-2. The current worktree fleet contains detached heads and preserved snapshots, which means useful work can exist without a named branch or PR path.
-3. `mainline-sweep` and `origin-reconcile` are intentionally blocked when `main` is checked out elsewhere or when the audit reports active drift.
-4. Status documents and control-plane notes can become stale if they are not refreshed from the live audit.
-5. There is no dedicated, automated "merge cadence" watchdog that forces attention when no PRs or merges happen for too long.
+1. The repo already has a fail-closed mainline gate (`branch-gate`, `mainline-audit`, `mainline-sweep`, `origin-reconcile`), and local `main` now matches `origin/main` at `3e890f8`.
+2. The worktree fleet still contains many detached archival copies plus this maintenance checkout at older commit `e380c72`, so restart ownership is still easy to blur.
+3. Two preserved recovery branches remain intentionally outside the sweep path until they are either archived or promoted deliberately.
+4. Status documents and control-plane notes become stale quickly if they are not refreshed from the live audit after a pause.
+5. The hourly watchdog exists, but human restart ownership is still required before merge-oriented automation resumes.
 
-The root problem is therefore not "missing code". It is "missing promotion discipline".
+The root problem is therefore no longer "missing code". It is "clean restart ownership".
 
 ## Recovery Principles
 
@@ -32,28 +35,26 @@ The root problem is therefore not "missing code". It is "missing promotion disci
 
 | Workstream | Outcome | Owner | Dependencies | Verification | Exit Criteria |
 | --- | --- | --- | --- | --- | --- |
-| Canonical integration lease | One clean worktree owns `main`; all other worktrees are branch-only or snapshot-only. | DevOps-Engineer, Project-Manager | Access to the active worktree fleet; ability to free the `main` checkout conflict. | `git worktree list`; `./scripts/codex_wsl_tasks.sh mainline-audit --json`; `./scripts/codex_wsl_tasks.sh branch-gate` | Only one canonical integration worktree is allowed to run sweep/reconcile; audit no longer reports a checkout conflict. |
-| Branch-to-PR promotion | Every ready slice becomes a named branch and a draft or ready PR automatically. | Project-Manager, lane owners | GitHub auth for PR creation; branch naming convention; branch-gate discipline. | `./scripts/codex_wsl_tasks.sh branch-gate`; GitHub PR creation command or API call; PR checklist includes branch name and HEAD SHA. | No completed work remains trapped on detached HEAD; each promotable slice has a branch, PR, and owner. |
-| Mainline sweep and reconcile | Local `main` folds eligible branches and fast-forward pushes to `origin/main`. | Project-Manager, DevOps-Engineer | Canonical integration lease; clean worktree; green verification ladder. | `./scripts/codex_wsl_tasks.sh mainline-sweep --verify`; `./scripts/codex_wsl_tasks.sh origin-reconcile` | Sweep and reconcile succeed from the canonical integration worktree without manual intervention. |
+| Canonical integration lease | One clean worktree owns `main`; detached archival copies stay out of the merge path. | DevOps-Engineer, Project-Manager | Access to the active worktree fleet; ability to start from a clean `main`-attached checkout. | `git worktree list`; `./scripts/codex_wsl_tasks.sh mainline-audit --json`; `./scripts/codex_wsl_tasks.sh branch-gate` | One integration worktree is clearly designated for sweep/reconcile; detached archival copies are documented as non-authoritative. |
+| Recovery branch triage | The two preserved recovery branches are either archived as obsolete or promoted intentionally. | Project-Manager, lane owners | Semantic diff review; branch naming convention; branch-gate discipline if replay is needed. | `git log --oneline main..codex/recovery-*`; focused tests for any replayed slice; PR creation if promoted. | No preserved recovery branch remains ambiguous about whether it is backlog, replay, or archive-only history. |
+| Mainline verification and reconcile | Local `main` stays aligned with `origin/main`; sweep/reconcile run only when new tracked drift appears. | Project-Manager, DevOps-Engineer | Canonical integration lease; clean worktree; green verification ladder. | `./scripts/codex_wsl_tasks.sh mainline-sweep --verify`; `./scripts/codex_wsl_tasks.sh origin-reconcile` | Sweep/reconcile remain green and fail-closed without trying to consume archival detached worktrees. |
 | Unattended watchdogs | Stalls are visible within minutes instead of days. | DevOps-Engineer | Metrics/logging target; automation runner schedule. | Scheduled `mainline-audit`; alert on no PR creation or no merge within threshold. | A stalled control plane triggers an alert and a structured stop record automatically. |
 | Live docs sync | Human-readable docs always match the live mainline state. | Docs-Writer, Project-Manager | Live audit output; sweep/reconcile completion. | Refresh `status.md`, `docs/automation_control_plane.md`, `docs/roadmap.md`, and `docs/source_of_truth_integration.md` from the current audit snapshot. | Docs show the actual blocker state, the current resume order, and the active integration owner. |
 
 ## Execution Sequence
 
-1. Inventory every active worktree and classify it as canonical, branch-backed, or snapshot-only.
-2. Free or reassign any non-canonical `main` checkout so exactly one integration worktree owns the merge path.
-3. Refresh the live audit snapshot and record the exact blocker state before any remediation.
-4. Convert promotable detached work into named branches.
-5. Auto-create PRs for those branches so completed work is visible and reviewable.
-6. Run `./scripts/codex_wsl_tasks.sh mainline-sweep --verify` from the canonical integration worktree.
-7. Run `./scripts/codex_wsl_tasks.sh origin-reconcile` only after the sweep and validation ladder pass.
-8. Resume automation runners in the documented order once the audit is clean.
-9. Keep the audit/watchdog running so the system fails visibly instead of silently stalling.
+1. Align local `main` with `origin/main` and capture the fresh audit snapshot.
+2. Pick one clean worktree attached to `main` as the canonical integration lease.
+3. Classify detached worktrees at or behind `main` as archival unless they show new semantic drift.
+4. Triage the two preserved recovery branches and decide whether they are archive-only or promotion candidates.
+5. Run `./scripts/codex_wsl_tasks.sh mainline-sweep --verify` and `./scripts/codex_wsl_tasks.sh origin-reconcile` only from the canonical integration worktree when new tracked drift appears.
+6. Resume automation runners in the documented order once the audit is clean and the integration lease is explicit.
+7. Keep the audit/watchdog running so the system fails visibly instead of silently stalling.
 
 ## Operational Rules
 
 - Do not relax `require_main_available` or `require_no_active_drift`.
-- Do not let a detached head be the only copy of promotable work.
+- Do not let a detached head or archival worktree become the accidental source of new production work.
 - Do not allow multiple runners to contend for the same `main` checkout.
 - Do not treat "no PRs" as acceptable if ready work exists.
 - Do not merge without the verification ladder succeeding.
@@ -76,6 +77,7 @@ If any of those fields are missing, the run is not ready for unattended operatio
 ## Success Criteria
 
 - One canonical integration worktree owns `main`.
+- local `main` matches `origin/main`.
 - `mainline-audit` reports no active newer-than-main drift and no checkout conflict.
 - Every ready slice has a named branch and a PR.
 - `mainline-sweep --verify` passes.
@@ -85,9 +87,9 @@ If any of those fields are missing, the run is not ready for unattended operatio
 
 ## Immediate Next Actions
 
-1. Re-run the live audit from the canonical integration worktree.
-2. Promote any eligible detached work to named branches.
-3. Create or reopen PRs for the promoted branches.
-4. Run the sweep and reconcile commands from the canonical worktree.
-5. Refresh the status and freeze documents from the live audit output.
+1. Start a clean `main`-attached integration worktree for active delivery.
+2. Re-run the live audit from that worktree and confirm no new tracked drift appears.
+3. Decide whether the two preserved recovery branches are archive-only or need deliberate replay.
+4. Run the backend auth/quota verification slice before reopening frontend work.
+5. Refresh the status and control-plane documents from the live audit output whenever the baseline moves again.
 6. Re-enable the paused runners only after the resume gates are met.

--- a/status.md
+++ b/status.md
@@ -1,6 +1,6 @@
 # PODPusher Status
 
-Last updated: March 27, 2026 (America/New_York)
+Last updated: April 5, 2026 (America/New_York)
 Maintainer: PODPusher Coordinator (`podpusher-delivery`)
 
 This file tracks current delivery state and detached-worktree triage outcomes. Long-form historical completion logs are intentionally omitted; active execution state is authoritative.
@@ -15,9 +15,9 @@ This file tracks current delivery state and detached-worktree triage outcomes. L
 
 - State: `ACTIVE`.
 - Governing doc: [docs/automation_control_plane.md](docs/automation_control_plane.md)
-- Live state: `main` and `origin/main` both point at `0b7f99a`; the canonical integration worktree is `/mnt/d/Users/Bear/.codex-data/worktrees/dd0c/PODPusher`.
+- Live state: local `main` and `origin/main` both point at `3e890f8`; this maintenance checkout remains detached at `e380c72`, so merge-oriented work should resume from a clean `main`-attached worktree rather than the current checkout.
 - Backlog branches still awaiting deliberate triage: `codex/recovery-snapshot-20260325` at `837e167acd8b984825ba734013bef228ceab0060`, `codex/recovery-local-recreate-pr70-20260326` at `c7b5000cc0e32d164ad3ed6ef6c667af27dc3902`.
-- Resume order: `podpusher-mainline-sweep`, `origin-reconcile`, `podpusher-coordinator`, `podpusher-backend-lane`, `podpusher-frontend-lane`, `podpusher-platform-qa-lane`, `podpusher-integrations-lane`, `podpusher-cleanup`.
+- Resume order: `podpusher-mainline-watchdog`, `podpusher-coordinator`, `podpusher-backend-lane`, `podpusher-frontend-lane`, `podpusher-platform-qa-lane`, `podpusher-integrations-lane`, `podpusher-cleanup`. Run `podpusher-mainline-sweep` and `origin-reconcile` only when new tracked drift appears.
 
 ## Lane Assignments
 
@@ -30,8 +30,8 @@ This file tracks current delivery state and detached-worktree triage outcomes. L
 
 ## Variance Resolution Note
 
-This cycle consolidated planner/status detached variance from worktrees:
-`0550`, `9b4d`, `94f0`, `72c3`, `1897`, `8696`, `5188`, `4808`.
+This cycle refreshed the control-plane docs after a one-week shutdown and
+realigned the local `main` ref with `origin/main` before lane work resumes.
 
 Consolidation rules applied:
 - Preferred latest concrete lane ownership + boundaries + verification commands.
@@ -41,8 +41,9 @@ Consolidation rules applied:
 
 ## Mainline Convergence Snapshot
 
-- Live audit baseline: `mainline-audit --json` on March 27, 2026 now reports clean mainline convergence.
+- Live audit baseline: `mainline-audit --json` on April 5, 2026 reports local `main` and `origin/main` both at `3e890f8`.
 - Active newer-than-main merge candidate: none.
+- Detached archival worktrees already sitting on `3e890f8` are duplicate baseline copies, not promotable drift.
 - Older unmerged replay lines that still require deliberate manual triage:
   - `codex/recovery-snapshot-20260325` at `837e167acd8b984825ba734013bef228ceab0060`
   - `codex/recovery-local-recreate-pr70-20260326` at `c7b5000cc0e32d164ad3ed6ef6c667af27dc3902`


### PR DESCRIPTION
## Summary
- realign the documented mainline/control-plane baseline with the live `origin/main` state after the project pause
- replace the stale quota/image-review pending-work narrative with the actual remaining manual triage backlog
- document that new merge-oriented work should restart from a clean `main`-attached worktree and keep the preserved recovery branches out of the active sweep path

## Why
The repository had drift between its operational docs and the real git topology. `main` was one commit behind `origin/main`, the local checkout was detached, and the docs still described already-landed product slices as pending.

## Validation
- `python3 -m pytest -q -s tests/test_mainline_docs_contract.py tests/test_mainline_tools_contract.py tests/test_mainline_verify_contract.py`
- `python3 -m pytest -q -s tests/test_auth.py tests/test_gateway.py tests/test_quota.py tests/test_rate_limit_middleware.py`